### PR TITLE
Fix Twilio A2P SMS campaign: TCPA-compliant opt-in

### DIFF
--- a/src/app/(public)/privacy/PrivacyPageContent.tsx
+++ b/src/app/(public)/privacy/PrivacyPageContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import {
   Text,
   Container,
@@ -213,11 +214,20 @@ export default function PrivacyPageContent() {
 
             <Box data-testid="privacy-section-7">
               <Stack spacing="md">
-                <H4 data-testid="privacy-section-title-7" cmsId="sections-7-title">
-                  {cmsData?.['sections-7-title'] || '8. Third-Party Links'}
+                <H4 data-testid="privacy-section-title-7">
+                  8. SMS & Text Message Communications
                 </H4>
-                <Text data-testid="privacy-section-content-7" cmsId="sections-7-content">
-                  {cmsData?.['sections-7-content'] || 'Our website may contain links to third-party websites. We are not responsible for the privacy practices of these external sites. We encourage you to review their privacy policies.'}
+                <Text data-testid="privacy-section-content-7">
+                  When you opt in to receive SMS messages during the booking process, we collect and store your phone number and SMS consent status. We use this information to send you:
+                </Text>
+                <Stack spacing="sm">
+                  <Text>{'\u2022'} Booking confirmations and status updates</Text>
+                  <Text>{'\u2022'} Pickup reminders and driver notifications</Text>
+                  <Text>{'\u2022'} Occasional promotional offers (no more than 4 per month)</Text>
+                </Stack>
+                <Text>
+                  SMS consent is not required to use our services. You may opt out at any time by replying STOP to any message, or by unchecking the SMS consent checkbox during your next booking. Your phone number is not sold, rented, or shared with third parties for their marketing purposes. For full details, see our{' '}
+                  <Link href="/sms-terms" style={{ textDecoration: 'underline' }}>SMS Terms & Conditions</Link>.
                 </Text>
               </Stack>
             </Box>
@@ -225,10 +235,21 @@ export default function PrivacyPageContent() {
             <Box data-testid="privacy-section-8">
               <Stack spacing="md">
                 <H4 data-testid="privacy-section-title-8" cmsId="sections-8-title">
-                  {cmsData?.['sections-8-title'] || '9. Contact Us'}
+                  {cmsData?.['sections-8-title'] || '9. Third-Party Links'}
                 </H4>
                 <Text data-testid="privacy-section-content-8" cmsId="sections-8-content">
-                  {cmsData?.['sections-8-content'] || 'If you have questions about this Privacy Policy or how we handle your information, please contact us: Fairfield Airport Cars, Text: (646) 221-6370, Email: rides@fairfieldairportcar.com'}
+                  {cmsData?.['sections-8-content'] || 'Our website may contain links to third-party websites. We are not responsible for the privacy practices of these external sites. We encourage you to review their privacy policies.'}
+                </Text>
+              </Stack>
+            </Box>
+
+            <Box data-testid="privacy-section-9">
+              <Stack spacing="md">
+                <H4 data-testid="privacy-section-title-9" cmsId="sections-9-title">
+                  {cmsData?.['sections-9-title'] || '10. Contact Us'}
+                </H4>
+                <Text data-testid="privacy-section-content-9" cmsId="sections-9-content">
+                  {cmsData?.['sections-9-content'] || 'If you have questions about this Privacy Policy or how we handle your information, please contact us: Fairfield Airport Cars, Text: (646) 221-6370, Email: rides@fairfieldairportcar.com'}
                 </Text>
               </Stack>
             </Box>

--- a/src/app/(public)/sms-terms/SmsTermsContent.tsx
+++ b/src/app/(public)/sms-terms/SmsTermsContent.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import {
+  Text,
+  Container,
+  Stack,
+  Box,
+  H1,
+  H4
+} from '@/design/ui';
+
+export default function SmsTermsContent() {
+  return (
+    <>
+      {/* Hero Section */}
+      <Container maxWidth="full" padding="xl" variant="section">
+        <Stack spacing="xl" align="center">
+          <Stack spacing="md" align="center">
+            <H1 align="center" data-testid="sms-terms-title">
+              SMS Terms & Conditions
+            </H1>
+            <Text variant="lead" align="center" size="lg" data-testid="sms-terms-effective-date">
+              Effective Date: February 2025
+            </Text>
+          </Stack>
+        </Stack>
+      </Container>
+
+      {/* Content Section */}
+      <Container maxWidth="2xl" padding="xl">
+        <Stack spacing="lg">
+          <Box data-testid="sms-terms-program">
+            <Stack spacing="md">
+              <H4>Program Name</H4>
+              <Text>
+                Fairfield Airport Car Service SMS Alerts
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-description">
+            <Stack spacing="md">
+              <H4>1. Program Description</H4>
+              <Text>
+                By opting in to SMS messages from Fairfield Airport Car Service, you consent to receive text messages related to our airport transportation services. These messages may include:
+              </Text>
+              <Stack spacing="sm">
+                <Text>{'\u2022'} Booking confirmations and updates</Text>
+                <Text>{'\u2022'} Pickup reminders (typically 24 hours before your scheduled ride)</Text>
+                <Text>{'\u2022'} Driver status notifications (assignment, en route, arrival)</Text>
+                <Text>{'\u2022'} Post-ride feedback requests</Text>
+                <Text>{'\u2022'} Occasional promotional offers and deals</Text>
+              </Stack>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-consent">
+            <Stack spacing="md">
+              <H4>2. Consent & Opt-In</H4>
+              <Text>
+                You may opt in to receive SMS messages by checking the SMS consent checkbox during the booking process on our website at fairfieldairportcars.com. By checking the box labeled &quot;I agree to receive SMS messages from Fairfield Airport Car Service,&quot; you provide your express written consent to receive text messages at the phone number you provide.
+              </Text>
+              <Text>
+                Consent is not required as a condition of purchasing any goods or services. You may book a ride without opting in to SMS messages.
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-frequency">
+            <Stack spacing="md">
+              <H4>3. Message Frequency</H4>
+              <Text>
+                Message frequency varies based on your booking activity. Transactional messages (confirmations, reminders, driver updates) are sent as needed when you have an active booking. Promotional messages are sent no more than 4 times per month.
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-costs">
+            <Stack spacing="md">
+              <H4>4. Message & Data Rates</H4>
+              <Text>
+                Message and data rates may apply. Fairfield Airport Car Service does not charge for SMS messages, but your mobile carrier&apos;s standard messaging rates may apply. Please contact your carrier for details about your messaging plan.
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-optout">
+            <Stack spacing="md">
+              <H4>5. Opt-Out Instructions</H4>
+              <Text>
+                You can opt out of receiving SMS messages at any time by replying STOP to any message you receive from us. After you send STOP, you will receive a one-time confirmation message. After that, you will no longer receive SMS messages from us.
+              </Text>
+              <Text>
+                You may also opt out by unchecking the SMS consent checkbox during your next booking, or by contacting us directly.
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-help">
+            <Stack spacing="md">
+              <H4>6. Help</H4>
+              <Text>
+                For help or questions about our SMS program, reply HELP to any message, or contact us at:
+              </Text>
+              <Stack spacing="sm">
+                <Text>{'\u2022'} Text: (646) 221-6370</Text>
+                <Text>{'\u2022'} Email: rides@fairfieldairportcar.com</Text>
+              </Stack>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-carriers">
+            <Stack spacing="md">
+              <H4>7. Supported Carriers</H4>
+              <Text>
+                SMS messages are supported on all major US carriers including AT&T, Verizon, T-Mobile, Sprint, and others. Carriers are not liable for delayed or undelivered messages.
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-privacy">
+            <Stack spacing="md">
+              <H4>8. Privacy</H4>
+              <Text>
+                Your phone number and SMS consent status are stored securely and used only for the purposes described in this policy. We do not sell, rent, or share your phone number with third parties for marketing purposes. For more details, see our{' '}
+                <Link href="/privacy" style={{ textDecoration: 'underline' }}>Privacy Policy</Link>.
+              </Text>
+            </Stack>
+          </Box>
+
+          <Box data-testid="sms-terms-contact">
+            <Stack spacing="md">
+              <H4>9. Contact Us</H4>
+              <Text>
+                Fairfield Airport Car Service
+              </Text>
+              <Stack spacing="sm">
+                <Text>Text: (646) 221-6370</Text>
+                <Text>Email: rides@fairfieldairportcar.com</Text>
+                <Text>Web: fairfieldairportcars.com</Text>
+              </Stack>
+            </Stack>
+          </Box>
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/app/(public)/sms-terms/page.tsx
+++ b/src/app/(public)/sms-terms/page.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SmsTermsContent from './SmsTermsContent';
+
+export async function generateMetadata() {
+  return {
+    title: 'SMS Terms & Conditions - Fairfield Airport Cars',
+    description: 'SMS terms and conditions for Fairfield Airport Car Service text message alerts and notifications.',
+    keywords: 'SMS terms, text message policy, airport transportation, Fairfield, opt-in, opt-out',
+  };
+}
+
+export default function SmsTermsPage() {
+  return <SmsTermsContent />;
+}

--- a/src/components/booking/ContactInfoPhase.tsx
+++ b/src/components/booking/ContactInfoPhase.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
+import Link from 'next/link';
 import { Container, Stack, Text, Button, Box, Input, Textarea, RadioButton, H2, Label } from '@/design/ui';
 import { CustomerInfo, ValidationResult } from '@/types/booking';
 import { useCMSData } from '../../design/providers/CMSDataProvider';
@@ -63,6 +64,10 @@ const ErrorMessageBox = styled.div`
 
 const SmsDisclaimerText = styled(Text)`
   margin-left: 28px;
+`;
+
+const SmsTermsLink = styled(Link)`
+  text-decoration: underline;
 `;
 
 /**
@@ -295,10 +300,11 @@ export function ContactInfoPhase({
                 checked={customerData.smsOptIn}
                 onChange={() => onCustomerUpdate({ smsOptIn: !customerData.smsOptIn })}
                 data-testid="sms-opt-in-checkbox"
-                label="Send me occasional deals and promotions via text message"
+                label="I agree to receive SMS messages from Fairfield Airport Car Service including booking confirmations, reminders, and occasional promotions."
               />
               <SmsDisclaimerText variant="small" color="secondary">
-                Message frequency varies. Msg & data rates may apply. Reply STOP to unsubscribe.
+                Msg frequency varies. Msg & data rates may apply. Reply STOP to opt out, HELP for help.{' '}
+                <SmsTermsLink href="/sms-terms">SMS Terms & Conditions</SmsTermsLink>
               </SmsDisclaimerText>
             </Stack>
           </Stack>

--- a/src/design/page-sections/Footer.tsx
+++ b/src/design/page-sections/Footer.tsx
@@ -44,13 +44,17 @@ export const Footer: React.FC = () => {
       label: cmsData?.['links-privacy-label'] || 'Privacy', 
       href: '/privacy' 
     },
-    { 
-      label: cmsData?.['links-terms-label'] || 'Terms', 
-      href: '/terms' 
+    {
+      label: cmsData?.['links-terms-label'] || 'Terms',
+      href: '/terms'
     },
-    { 
-      label: cmsData?.['links-contact-label'] || 'Contact', 
-      href: '/contact' 
+    {
+      label: 'SMS Terms',
+      href: '/sms-terms'
+    },
+    {
+      label: cmsData?.['links-contact-label'] || 'Contact',
+      href: '/contact'
     },
   ];
 

--- a/src/providers/BookingProvider.tsx
+++ b/src/providers/BookingProvider.tsx
@@ -115,7 +115,7 @@ export const BookingProvider: React.FC<BookingProviderProps> = ({ children, exis
       phone: '',
       notes: '',
       saveInfoForFuture: false,
-      smsOptIn: true // Default checked per business preference
+      smsOptIn: false // Default unchecked for TCPA compliance (affirmative consent required)
     },
     payment: {
       depositAmount: null,
@@ -865,7 +865,7 @@ const [warning, setWarning] = useState<string | null>(null);
         phone: '',
         notes: '',
         saveInfoForFuture: false,
-        smsOptIn: true // Default checked per business preference
+        smsOptIn: false // Default unchecked for TCPA compliance (affirmative consent required)
       },
       payment: {
         depositAmount: null,


### PR DESCRIPTION
## Summary
- Created `/sms-terms` page with full SMS Terms & Conditions (required by TCR/CTIA for A2P 10DLC approval)
- Changed SMS opt-in checkbox default from **checked to unchecked** (TCPA requires affirmative consent)
- Updated consent language to explicit "I agree to receive SMS messages from Fairfield Airport Car Service" wording with link to SMS Terms
- Added SMS data usage section to Privacy Policy
- Added "SMS Terms" link to site footer for TCR reviewer discoverability

## Why
The A2P 10DLC campaign (CM22a2ecb16ab215f1220eae7d28ff4056) was **rejected** by TCR for:
1. **CTA verification failed** - no compliant opt-in mechanism visible on website
2. **Opt-in information insufficient** - description lacked proper consent disclosure

## After Deploying
Resubmit the campaign in Twilio Console with:
- **CTA description:** "Customers opt-in by checking an unchecked checkbox during booking at fairfieldairportcars.com/book. Full SMS terms at fairfieldairportcars.com/sms-terms."
- **Opt-out:** "Reply STOP to any message"

## Test plan
- [ ] Visit `/sms-terms` and verify all 9 sections render
- [ ] Visit `/book`, go to Contact Info phase - confirm SMS checkbox is **unchecked** by default
- [ ] Confirm checkbox label says "I agree to receive SMS messages..."
- [ ] Confirm "SMS Terms & Conditions" link below checkbox navigates to `/sms-terms`
- [ ] Visit `/privacy` and verify new Section 8 (SMS & Text Message Communications) exists
- [ ] Check footer contains "SMS Terms" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily content and UI copy/link changes; main behavioral change is defaulting SMS opt-in to unchecked, which could reduce SMS subscriptions but is unlikely to impact core booking flow.
> 
> **Overview**
> Updates the booking SMS consent flow to be **TCPA-compliant** by defaulting `customer.smsOptIn` to `false`, strengthening the checkbox consent language, and adding an inline link to `SMS Terms & Conditions`.
> 
> Adds a new public `/sms-terms` page (with metadata) and links it from the footer, and updates the Privacy Policy to include a new *SMS & Text Message Communications* section while shifting the existing section numbering/content accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34dd3acedbcedfa01c6142874b50971817bdcb82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->