### PR TITLE
fix(tracking): stop infinite fetch loop on live tracking page (+ CI svg typecheck)

### DIFF
--- a/src/app/(public)/tracking/[bookingId]/TrackingPageClient.tsx
+++ b/src/app/(public)/tracking/[bookingId]/TrackingPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { 
   Container, 
@@ -33,7 +33,10 @@ interface TrackingPageClientProps {
 export default function TrackingPageClient({ bookingId }: TrackingPageClientProps) {
   // Get CMS data from provider - extract only what this page needs
   const { cmsData: allCmsData } = useCMSData();
-  const cmsData = allCmsData?.tracking || {};
+  // Memoize so the reference is stable across renders. Previously `|| {}` minted a
+  // new object every render, which — when used as a useEffect dependency — caused the
+  // load effect to re-fire on every render (infinite fetch + Firebase-listener loop).
+  const cmsData = useMemo(() => allCmsData?.tracking || {}, [allCmsData]);
   const searchParams = useSearchParams();
   const trackingToken = searchParams?.get('token') ?? undefined;
   
@@ -48,19 +51,28 @@ export default function TrackingPageClient({ bookingId }: TrackingPageClientProp
 
   // Load booking data and initialize Firebase tracking
   useEffect(() => {
+    // Guards against the async chain settling after this effect run is torn down
+    // (unmount, or a bookingId/trackingToken change). Without it, late-resolving
+    // promises call setState on a stale render and can register a Firestore listener
+    // after cleanup already ran — leaking the subscription.
+    let cancelled = false;
+
     const loadBooking = async () => {
       try {
         setLoading(true);
         setError(null);
+        setTrackingActive(false);
 
         const url = trackingToken
           ? `/api/booking/${bookingId}?token=${encodeURIComponent(trackingToken)}`
           : `/api/booking/${bookingId}`;
         const response = await fetch(url);
+        if (cancelled) return;
         if (!response.ok) {
           throw new Error('Failed to fetch booking');
         }
         const bookingData = await response.json();
+        if (cancelled) return;
         if (!bookingData) {
           setError(cmsData?.['tracking-bookingNotFound'] || 'Booking not found');
           return;
@@ -76,8 +88,15 @@ export default function TrackingPageClient({ bookingId }: TrackingPageClientProp
 
         // Initialize Firebase tracking
         await firebaseTrackingService.initializeTracking(bookingId);
+        // If this run was cancelled while initializeTracking was in flight, the cleanup
+        // has already run its stopTracking. Tear down the subscription this call just
+        // created (otherwise it outlives the component) and bail before touching state.
+        if (cancelled) {
+          firebaseTrackingService.stopTracking(bookingId);
+          return;
+        }
         setTrackingActive(true);
-        
+
         // Set up location update callback
         firebaseTrackingService.onLocationUpdate(bookingId, (location: DriverLocation) => {
           setBooking(prev => prev ? {
@@ -109,6 +128,7 @@ export default function TrackingPageClient({ bookingId }: TrackingPageClientProp
                 speed: bookingData.driverLocation.speed || 0
               } : undefined
             );
+            if (cancelled) return;
             setETACalculation(initialETA);
           } catch {
             // Initial ETA is optional; page still renders with live updates.
@@ -116,9 +136,10 @@ export default function TrackingPageClient({ bookingId }: TrackingPageClientProp
         }
 
       } catch {
+        if (cancelled) return;
         setError(cmsData?.['tracking-loadFailed'] || 'Failed to load booking information');
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
@@ -126,13 +147,18 @@ export default function TrackingPageClient({ bookingId }: TrackingPageClientProp
       loadBooking();
     }
 
-    // Cleanup on unmount
+    // Cleanup on unmount / dependency change. stopTracking is idempotent (no-ops when
+    // nothing is subscribed), so we call it unconditionally rather than gating on the
+    // `trackingActive` state — reading that here would capture a stale closure value.
     return () => {
-      if (trackingActive) {
-        firebaseTrackingService.stopTracking(bookingId);
-      }
+      cancelled = true;
+      firebaseTrackingService.stopTracking(bookingId);
     };
-  }, [bookingId, trackingActive, cmsData]);
+    // Intentionally depends only on the tracking identity. cmsData is excluded (it is
+    // used only for fallback error strings) and trackingActive is excluded (it is set
+    // inside this effect); including either re-fires the effect and re-initializes
+    // tracking on every render.
+  }, [bookingId, trackingToken]);
 
   // Handle ETA updates
   const handleETAUpdate = (eta: ETACalculation) => {

--- a/tests/unit/tracking-page-client-no-loop.test.tsx
+++ b/tests/unit/tracking-page-client-no-loop.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Regression test: TrackingPageClient must not enter an infinite fetch loop.
+ *
+ * Bug (fixed): the booking-load useEffect depended on `cmsData` (recreated as a new
+ * `{}` on every render via `allCmsData?.tracking || {}`) and on `trackingActive`
+ * (set inside the effect). Both caused the effect to re-fire on every render, firing
+ * an unbounded stream of `/api/booking/:id` fetches and pinning the page on the
+ * "Loading enhanced tracking information..." state.
+ *
+ * This test renders the component with CMS data that has NO `tracking` key — the
+ * exact condition that triggered the `|| {}` instability — and asserts the booking
+ * endpoint is hit exactly once and the page escapes the loading state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server';
+
+// CMS data WITHOUT a `tracking` key — forces the component down the fallback path
+// that previously minted a new object every render. Module-level constant so the
+// reference is stable across renders (mirrors a real, stable provider value).
+const CMS_DATA_NO_TRACKING = { someOtherPage: { title: 'x' } };
+
+vi.mock('@/design/providers/CMSDataProvider', () => ({
+  useCMSData: () => ({ cmsData: CMS_DATA_NO_TRACKING }),
+}));
+
+// The map and ETA widgets pull in Google Maps; stub them — they are irrelevant to
+// the fetch-loop behavior under test.
+vi.mock('@/components/business/TrackingMap', () => ({
+  TrackingMap: () => <div data-testid="tracking-map" />,
+}));
+vi.mock('@/components/business/TrafficETA', () => ({
+  TrafficETA: () => <div data-testid="traffic-eta" />,
+}));
+vi.mock('@/components/business/AddToCalendarButton', () => ({
+  AddToCalendarButton: () => <div data-testid="add-to-calendar" />,
+}));
+
+// Stub the tracking service so initialization resolves without loading Google Maps.
+// Spies are created via vi.hoisted so they exist when the hoisted vi.mock factory runs.
+const { initializeTracking, stopTracking } = vi.hoisted(() => ({
+  initializeTracking: vi.fn().mockResolvedValue(undefined),
+  stopTracking: vi.fn(),
+}));
+vi.mock('@/lib/services/firebase-tracking-service', () => ({
+  firebaseTrackingService: {
+    initializeTracking,
+    stopTracking,
+    onLocationUpdate: vi.fn(),
+    onETAUpdate: vi.fn(),
+    calculateAdvancedETA: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import TrackingPageClient from '@/app/(public)/tracking/[bookingId]/TrackingPageClient';
+
+const BOOKING_ID = 'A3NUUQ';
+
+describe('TrackingPageClient — no infinite fetch loop', () => {
+  let bookingFetchCount = 0;
+
+  beforeEach(() => {
+    bookingFetchCount = 0;
+    initializeTracking.mockClear();
+    server.use(
+      http.get('/api/booking/:bookingId', ({ params }) => {
+        bookingFetchCount += 1;
+        return HttpResponse.json({
+          id: params.bookingId,
+          status: 'pending',
+          name: 'John Smith',
+          email: 'john@example.com',
+          phone: '203-555-0123',
+          pickupLocation: 'Fairfield Station, Fairfield, CT',
+          dropoffLocation: 'JFK Airport, Queens, NY',
+          pickupDateTime: '2026-07-01T10:00:00.000Z',
+          fare: 95.5,
+        });
+      }),
+    );
+  });
+
+  it('fetches the booking exactly once and escapes the loading state', async () => {
+    render(<TrackingPageClient bookingId={BOOKING_ID} />);
+
+    // Page must leave the "Loading enhanced tracking information..." state and render
+    // the booking details (booking id is shown in the details panel).
+    await waitFor(
+      () => {
+        expect(screen.getByText(BOOKING_ID)).toBeInTheDocument();
+      },
+      { timeout: 4000 },
+    );
+
+    // Give any runaway effect a chance to fire again before asserting the count.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(bookingFetchCount).toBe(1);
+    expect(initializeTracking).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes bundled — the first un-reds CI so the second can land green.

### 1. Tracking page infinite fetch loop (the field report) 🔴
`/tracking/[bookingId]` was stuck on *"Initializing real-time location tracking…"* while firing an unbounded stream of `/api/booking/:id` fetches (**742 pending** in the screenshot).

**Root cause:** the booking-load `useEffect` listed unstable/self-mutating deps `[bookingId, trackingActive, cmsData]`:
- `cmsData = allCmsData?.tracking || {}` minted a **new object every render** (the tracking CMS namespace is empty), so React saw the dep change every render.
- the effect calls `setTrackingActive(true)`, mutating its own dependency.

Result: render → effect → fetch + `setLoading(true)` + Firebase re-init → re-render → ∞. The page never left the loading state and leaked a Firestore `onSnapshot` listener per iteration.

**Fix:**
- `useMemo` the derived `cmsData` so its reference is stable.
- Reduce effect deps to `[bookingId, trackingToken]` (its real inputs).
- Cleanup calls `stopTracking` unconditionally (verified idempotent), not gated on the stale-closure `trackingActive`.
- Added a `cancelled` guard so a late-resolving async chain can't `setState` on a torn-down render or register a Firestore listener after cleanup ran (found in self-review).

### 2. CI `test` job red since March (commit `47d16cc`)
`tsc --noEmit` after a fresh `npm ci` fails because Next's gitignored `next-env.d.ts` is absent, so `*.svg` imports error with TS2307. Adds a tracked `next-assets.d.ts` mirroring next-env's reference. No-op locally.

## Tests
- New regression test `tests/unit/tracking-page-client-no-loop.test.tsx`: renders with an empty tracking CMS namespace (the exact trigger) and asserts the booking endpoint is fetched **exactly once**.
- **Verified it's a real guard:** fails on pre-fix code (**156 fetches**), passes after (**1**).
- Pre-push: full unit suite ✅, integration ✅, build ✅. E2E not run (no local dev server).

## Self-review (pre-PR gate)
Ran the code-review gate. Confirmed + fixed a listener-leak/setState-after-unmount race via the `cancelled` guard. Other findings triaged as low-severity/pre-existing/refuted (e.g. stale CMS *error-string* fallbacks — negligible since the tracking CMS namespace is empty; that emptiness is what caused the loop).

## Manual check recommended before/after deploy
Reload `/tracking/<id>` with DevTools Network open — expect a single `:id` request that resolves, then the page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)