### PR TITLE
fix(deploy): pin Node to 22.x (>=22 forced Node 24, broke all API routes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": "22.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Regression
After #29 deployed, **every API route 500'd** in prod (`/api/health`, `/api/booking/:id`, …) — crashing at the function level (framework `_error` HTML, the route's own try/catch never ran).

## Cause
`engines.node: ">=22"` made Vercel use **Node 24**, overriding the project's `22.x` setting (per the build-log warning). Node 24 was never tested — all local verification was on Node 22.

## Proof (production build, A/B)
- **Node 22 (local):** `/api/health` returns its own JSON → route executes.
- **Node 24 (prod):** same route returns framework HTML 500 → function crash.

## Fix
Pin `engines.node` to exact `"22.x"` (the tested runtime + the project's original setting). Also removes the `">=22"` auto-major-upgrade footgun Vercel warns against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)