### PR TITLE
fix(nav): dashboard cards navigate + remove dead admin Campaigns link

### DIFF
--- a/src/app/(customer)/dashboard/DashboardClient.tsx
+++ b/src/app/(customer)/dashboard/DashboardClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import {
   useToast,
   Container,
@@ -19,6 +20,7 @@ export default function DashboardClient() {
   const { cmsData: allCmsData } = useCMSData();
   const pageCmsData = allCmsData?.dashboard || {};
   const { addToast } = useToast();
+  const router = useRouter();
   
 
   const dashboardActions = [
@@ -27,14 +29,14 @@ export default function DashboardClient() {
       icon: "📋",
       label: pageCmsData?.['actions.bookings.label'] || 'My Bookings',
       description: pageCmsData?.['actions.bookings.description'] || 'View and manage your current and past bookings',
-      href: "/manage"
+      href: "/bookings"
     },
     {
       id: 2,
       icon: "📅",
       label: pageCmsData?.['actions.status.label'] || 'Booking Status',
       description: pageCmsData?.['actions.status.description'] || 'Check the status of your upcoming rides',
-      href: "/status"
+      href: "/bookings"
     },
     {
       id: 3,
@@ -113,11 +115,13 @@ export default function DashboardClient() {
           <Grid cols={{ xs: 1, md: 2, lg: 3 }} gap="lg">
             {dashboardActions.map((action) => (
               <GridItem key={action.id}>
-                <Box 
-                  variant="elevated" 
-                  padding="lg" 
-                  as="div" 
-                  onClick={action.onClick}
+                <Box
+                  variant="elevated"
+                  padding="lg"
+                  as="div"
+                  onClick={() =>
+                    action.onClick ? action.onClick() : router.push(action.href)
+                  }
                 >
                   <Stack spacing="md" align="center">
                     <Text size="3xl">{action.icon}</Text>

--- a/src/components/app/AdminNavigation.tsx
+++ b/src/components/app/AdminNavigation.tsx
@@ -31,7 +31,8 @@ export const AdminNavigation: React.FC = () => {
     { name: 'Messages', href: '/admin/messages', current: currentPath.startsWith('/admin/messages') },
     { name: 'Pricing', href: '/admin/pricing', current: currentPath === '/admin/pricing' },
     { name: 'Costs', href: '/admin/costs', current: currentPath === '/admin/costs' },
-    { name: 'Campaigns', href: '/admin/campaigns', current: currentPath === '/admin/campaigns' },
+    // 'Campaigns' removed: /admin/campaigns has no page (Next prefetched it -> 404).
+    // Restore this link when the campaigns page is built.
     { name: 'Schedule', href: '/admin/schedules', current: currentPath.startsWith('/admin/schedules') },
     { name: 'Health', href: '/admin/health', current: currentPath === '/admin/health' },
     { name: 'Settings', href: '/admin/settings', current: currentPath === '/admin/settings' },


### PR DESCRIPTION
## Two dead-link bugs (surfaced once pages rendered again)

1. **Dashboard quick-action cards never navigated.** Cards defined `href` but the render only wired `onClick`, so only "Contact Us" worked. Now the card `onClick` does `router.push(action.href)` (falling back to `action.onClick`). Also fixed two `href`s pointing at dynamic-only routes (404):
   - My Bookings: `/manage` → `/bookings` (the actual list page)
   - Booking Status: `/status` → `/bookings` (no `/status` list route exists)
2. **Admin "Campaigns" link → `/admin/campaigns`** has no page → Next prefetch 404 on every admin page. Removed until the page exists.

Verified: tsc 0, eslint clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)