### PR TITLE
Fix flight info not saving and new bookings missing from calendar

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react';
 import { Container, Stack, Text, Box, Button, Input, Label, LoadingSpinner, Alert, H1 } from '@/design/ui';
 import { authFetch } from '@/lib/utils/auth-fetch';
 import { formatDateTimeNoSeconds } from '@/utils/formatting';
+import { GoogleCalendarConnect } from '@/components/calendar/GoogleCalendarConnect';
 
 interface BusinessRulesForm {
   serviceArea: { normalRadiusMiles: number; extendedRadiusMiles: number };
@@ -212,6 +213,10 @@ export default function AdminSettingsPage() {
             </Stack>
             <Button variant="primary" size="sm" onClick={handleSaveNotifications} disabled={saving} text="Save notifications" />
           </Stack>
+        </Box>
+
+        <Box variant="outlined" padding="lg">
+          <GoogleCalendarConnect />
         </Box>
 
         <Box variant="outlined" padding="lg">

--- a/src/app/api/booking/[bookingId]/route.ts
+++ b/src/app/api/booking/[bookingId]/route.ts
@@ -4,7 +4,7 @@ import { getAdminDb } from '@/lib/utils/firebase-admin';
 import { getBooking } from '@/lib/services/booking-service';
 import { driverSchedulingService } from '@/lib/services/driver-scheduling-service';
 import { FieldValue } from 'firebase-admin/firestore';
-import { requireOwnerAdminOrTrackingToken, requireOwnerOrAdmin } from '@/lib/utils/auth-server';
+import { requireOwnerAdminOrTrackingToken } from '@/lib/utils/auth-server';
 
 export async function GET(
   request: NextRequest,
@@ -101,11 +101,25 @@ export async function PUT(
       return NextResponse.json({ error: 'Booking not found' }, { status: 404 });
     }
 
-    const accessResult = await requireOwnerOrAdmin(request, existingBooking);
+    // Tracking-token access (no Firebase session — e.g. a guest right after booking) is allowed here,
+    // but scoped down below to flight-info updates only.
+    const accessResult = await requireOwnerAdminOrTrackingToken(request, existingBooking);
     if (!accessResult.ok) return accessResult.response;
 
     if (existingBooking.status === 'cancelled') {
       return NextResponse.json({ error: 'Cannot edit a cancelled booking' }, { status: 400 });
+    }
+
+    const accessMode = 'access' in accessResult ? accessResult.access : undefined;
+    if (accessMode === 'tracking-token') {
+      const requestedKeys = Object.keys(body || {});
+      const disallowedKeys = requestedKeys.filter((key) => key !== 'flightInfo');
+      if (disallowedKeys.length > 0) {
+        return NextResponse.json(
+          { error: 'This link can only be used to update flight info. Please log in to edit other booking details.' },
+          { status: 403 }
+        );
+      }
     }
 
     // Track what changed for SMS notification
@@ -214,6 +228,31 @@ export async function PUT(
         updateData.pickupDateTime = newPickupDateTime;
         dateTimeChanged = true;
         changedFields.push('pickup date/time');
+      }
+    }
+
+    // Handle flight info update (post-submit flight info phase)
+    if (updates.flightInfo) {
+      const existingFlightInfo = existingTrip.flightInfo || {};
+      const mergedFlightInfo = {
+        ...existingFlightInfo,
+        ...updates.flightInfo,
+      };
+      const flightInfoChanged = (['hasFlight', 'airline', 'flightNumber', 'arrivalTime', 'terminal'] as const).some(
+        (key) => mergedFlightInfo[key] !== existingFlightInfo[key]
+      );
+
+      if (flightInfoChanged) {
+        updateData.trip = {
+          ...existingTrip,
+          ...updateData.trip, // Preserve other trip updates
+          flightInfo: mergedFlightInfo,
+        };
+        // Also update legacy flat field used by admin bookings table
+        if (updates.flightInfo.flightNumber !== undefined) {
+          updateData.flightNumber = updates.flightInfo.flightNumber;
+        }
+        changedFields.push('flight info');
       }
     }
 

--- a/src/app/api/booking/confirm/route.ts
+++ b/src/app/api/booking/confirm/route.ts
@@ -105,33 +105,17 @@ export async function POST(request: NextRequest) {
       
       // Sync calendar event for the now-confirmed booking
       try {
-        const { createBookingCalendarEvent, confirmBookingCalendarEvent } = await import('@/lib/services/google-calendar');
-        const pickupDateTime = bookingRecord.trip?.pickupDateTime || bookingRecord.pickupDateTime || new Date();
-        const tripData = bookingRecord.trip || {
-          pickup: { address: bookingRecord.pickupLocation || '' },
-          dropoff: { address: bookingRecord.dropoffLocation || '' },
-          pickupDateTime: pickupDateTime as Date | string,
-        };
-        const customerData = bookingRecord.customer || {
-          name: bookingRecord.name || '',
-          email: bookingRecord.email || '',
-        };
+        const { createBookingCalendarEvent, confirmBookingCalendarEvent, toCalendarBookingInput } = await import('@/lib/services/google-calendar');
+        const calendarBookingInput = toCalendarBookingInput(bookingId, bookingRecord);
 
         const existingCalendarEventId = bookingData?.calendarEventId;
         if (existingCalendarEventId) {
-          // A tentative event was already created at submission time — just clear the PENDING marker
-          await confirmBookingCalendarEvent(existingCalendarEventId, {
-            id: bookingId,
-            trip: tripData,
-            customer: customerData,
-          }, { smokeTest: isSmokeTest });
+          // A tentative event was already created at submission time — just clear the PENDING
+          // marker and re-sync timing in case the booking was edited before confirmation
+          await confirmBookingCalendarEvent(existingCalendarEventId, calendarBookingInput, { smokeTest: isSmokeTest });
         } else {
           // No tentative event exists (older booking, or it failed to create earlier) — create one now
-          const calendarEventId = await createBookingCalendarEvent({
-            id: bookingId,
-            trip: tripData,
-            customer: customerData,
-          }, { smokeTest: isSmokeTest });
+          const calendarEventId = await createBookingCalendarEvent(calendarBookingInput, { smokeTest: isSmokeTest });
 
           if (calendarEventId) {
             await db.collection('bookings').doc(bookingId).update({

--- a/src/app/api/booking/confirm/route.ts
+++ b/src/app/api/booking/confirm/route.ts
@@ -103,9 +103,9 @@ export async function POST(request: NextRequest) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (bookingRecord as any).calendarAddedByUser = bookingData?.calendarAddedByUser === true;
       
-      // Create calendar event for confirmed booking
+      // Sync calendar event for the now-confirmed booking
       try {
-        const { createBookingCalendarEvent } = await import('@/lib/services/google-calendar');
+        const { createBookingCalendarEvent, confirmBookingCalendarEvent } = await import('@/lib/services/google-calendar');
         const pickupDateTime = bookingRecord.trip?.pickupDateTime || bookingRecord.pickupDateTime || new Date();
         const tripData = bookingRecord.trip || {
           pickup: { address: bookingRecord.pickupLocation || '' },
@@ -116,22 +116,33 @@ export async function POST(request: NextRequest) {
           name: bookingRecord.name || '',
           email: bookingRecord.email || '',
         };
-        const calendarEventId = await createBookingCalendarEvent({
-          id: bookingId,
-          trip: tripData,
-          customer: customerData,
-        }, { smokeTest: isSmokeTest });
 
-        // Store calendar event ID in booking
-        if (calendarEventId) {
-          await db.collection('bookings').doc(bookingId).update({
-            calendarEventId: calendarEventId,
-            updatedAt: FieldValue.serverTimestamp()
-          });
+        const existingCalendarEventId = bookingData?.calendarEventId;
+        if (existingCalendarEventId) {
+          // A tentative event was already created at submission time — just clear the PENDING marker
+          await confirmBookingCalendarEvent(existingCalendarEventId, {
+            id: bookingId,
+            trip: tripData,
+            customer: customerData,
+          }, { smokeTest: isSmokeTest });
+        } else {
+          // No tentative event exists (older booking, or it failed to create earlier) — create one now
+          const calendarEventId = await createBookingCalendarEvent({
+            id: bookingId,
+            trip: tripData,
+            customer: customerData,
+          }, { smokeTest: isSmokeTest });
+
+          if (calendarEventId) {
+            await db.collection('bookings').doc(bookingId).update({
+              calendarEventId: calendarEventId,
+              updatedAt: FieldValue.serverTimestamp()
+            });
+          }
         }
       } catch (calendarError) {
-        console.error('Failed to create calendar event (non-blocking):', calendarError);
-        // Don't fail confirmation if calendar event creation fails
+        console.error('Failed to sync calendar event (non-blocking):', calendarError);
+        // Don't fail confirmation if calendar event sync fails
       }
 
       await sendConfirmationEmail(adaptOldBookingToNew(bookingRecord));

--- a/src/app/api/calendar/callback/route.ts
+++ b/src/app/api/calendar/callback/route.ts
@@ -1,6 +1,7 @@
 // src/app/api/calendar/callback/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { createOAuth2Client, getTokens, setCredentials, initializeCalendarAPI, storeCalendarTokens } from '@/lib/services/google-calendar';
+import { requireAdmin } from '@/lib/utils/auth-server';
 
 const calendarIntegrationEnabled = process.env.ENABLE_GOOGLE_CALENDAR === 'true';
 
@@ -11,6 +12,13 @@ export async function GET(request: NextRequest) {
       { status: 501 }
     );
   }
+
+  // API routes are excluded from middleware's admin gate (see matcher in middleware.ts),
+  // and this route persists whatever OAuth tokens it receives as the app's shared calendar
+  // credentials — without this check, anyone who completes Google's consent screen with
+  // their own account could hijack calendar write access.
+  const accessResult = await requireAdmin(request);
+  if (!accessResult.ok) return accessResult.response;
 
   try {
     const { searchParams } = new URL(request.url);

--- a/src/app/api/calendar/callback/route.ts
+++ b/src/app/api/calendar/callback/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/calendar/callback/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { createOAuth2Client, getTokens, setCredentials, initializeCalendarAPI } from '@/lib/services/google-calendar';
+import { createOAuth2Client, getTokens, setCredentials, initializeCalendarAPI, storeCalendarTokens } from '@/lib/services/google-calendar';
 
 const calendarIntegrationEnabled = process.env.ENABLE_GOOGLE_CALENDAR === 'true';
 
@@ -25,21 +25,20 @@ export async function GET(request: NextRequest) {
 
     const oauth2Client = createOAuth2Client();
     const tokens = await getTokens(oauth2Client, code);
-    
-    // Store tokens securely (in production, use a secure database)
-    // For now, we'll return them to the client
-    // TODO: Implement secure token storage
-    
+
     setCredentials(oauth2Client, tokens);
     const calendar = initializeCalendarAPI(oauth2Client);
-    
+
     // Test the connection
     const testResponse = await calendar.calendarList.list();
-    
+
+    // Persist tokens server-side (Firestore) so future requests don't need this flow again
+    await storeCalendarTokens(tokens);
+
     return NextResponse.json({
       success: true,
       message: 'Google Calendar connected successfully',
-      tokens: tokens, // Remove this in production
+      tokens: tokens, // Kept for the existing client-side availability-checker flow
       calendars: testResponse.data.items?.length || 0
     });
     

--- a/src/components/booking/FlightInfoPhase.tsx
+++ b/src/components/booking/FlightInfoPhase.tsx
@@ -40,7 +40,9 @@ export function FlightInfoPhase({
     formData,
     updateTripDetails,
     completeFlightInfo,
-    warning
+    warning,
+    error,
+    isSubmitting
   } = useBooking();
   
   const tripData = formData.trip;
@@ -109,6 +111,19 @@ export function FlightInfoPhase({
           cmsData={cmsData}
         />
 
+        {error && (
+          <WarningBox variant="filled" padding="lg" data-testid="flight-info-phase-error-message">
+            <Stack spacing="sm" align="center">
+              <Text size="lg" weight="bold" color="warning" align="center">
+                {cmsData?.['flight-info-save-error-title'] || '⚠️ Flight Info Not Saved'}
+              </Text>
+              <Text size="md" align="center" color="warning">
+                {error}
+              </Text>
+            </Stack>
+          </WarningBox>
+        )}
+
         {warning && (
           <WarningBox variant="filled" padding="lg" data-testid="flight-info-phase-warning-message">
             <Stack spacing="sm" align="center">
@@ -131,9 +146,10 @@ export function FlightInfoPhase({
             variant="primary"
             size="lg"
             onClick={completeFlightInfo}
+            disabled={isSubmitting}
             data-testid="flight-info-complete-button"
 
-            text={cmsData?.['flight-info-complete-button'] || 'Save Flight Info'}
+            text={isSubmitting ? 'Saving…' : (cmsData?.['flight-info-complete-button'] || 'Save Flight Info')}
             fullWidth
           />
         </Stack>

--- a/src/hooks/useGoogleCalendar.ts
+++ b/src/hooks/useGoogleCalendar.ts
@@ -1,5 +1,6 @@
 // src/hooks/useGoogleCalendar.ts
 import { useState, useCallback, useEffect } from 'react';
+import { authFetch } from '@/lib/utils/auth-fetch';
 
 const CALENDAR_ENABLED = process.env.NEXT_PUBLIC_ENABLE_GOOGLE_CALENDAR === 'true';
 const CALENDAR_DISABLED_MESSAGE =
@@ -83,7 +84,9 @@ export const useGoogleCalendar = () => {
       setLoading(true);
       setError(null);
       
-      const response = await fetch(`/api/calendar/callback?code=${code}`);
+      // /api/calendar/callback requires admin auth (it persists calendar credentials) —
+      // authFetch attaches the signed-in admin's Firebase ID token as a Bearer header.
+      const response = await authFetch(`/api/calendar/callback?code=${code}`);
       const data = await response.json();
       
       if (!response.ok) {

--- a/src/lib/contracts/booking-api.ts
+++ b/src/lib/contracts/booking-api.ts
@@ -136,6 +136,7 @@ export const submitBookingRequestSchema = z.object({
 export const submitBookingSuccessResponseSchema = z.object({
   success: z.literal(true),
   bookingId: z.string(),
+  trackingToken: z.string().optional(),
   totalFare: z.number(),
   message: z.string(),
   emailWarning: z.string().nullable().optional(),

--- a/src/lib/services/booking-cancellation.ts
+++ b/src/lib/services/booking-cancellation.ts
@@ -30,11 +30,10 @@ export const cancelBooking = async (
             setCredentials,
             initializeCalendarAPI,
             deleteBookingEvent,
+            getStoredCalendarTokens,
           } = await import('./google-calendar');
 
-          const storedTokens = process.env.GOOGLE_CALENDAR_TOKENS
-            ? JSON.parse(process.env.GOOGLE_CALENDAR_TOKENS)
-            : null;
+          const storedTokens = await getStoredCalendarTokens();
 
           if (storedTokens) {
             const oauth2Client = createOAuth2Client();

--- a/src/lib/services/booking-orchestrator.ts
+++ b/src/lib/services/booking-orchestrator.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from 'crypto';
 import { getAdminDb } from '@/lib/utils/firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 import { getQuote, isQuoteValid } from '@/lib/services/quote-service';
 import { createBookingAtomic, getBooking } from '@/lib/services/booking-service';
 import { sendBookingVerificationEmail, sendDriverNotificationEmail } from '@/lib/services/email-service';
@@ -128,6 +129,43 @@ function parseTimeSlotConflict(errorMessage: string): string[] {
     .split(',')
     .map((slot) => slot.trim())
     .filter(Boolean);
+}
+
+// Hold the time slot on the calendar as soon as the booking exists, marked PENDING until
+// the customer confirms. Non-throwing: calendar sync failures must never block a booking.
+async function createTentativeCalendarEventForBooking(
+  bookingId: string,
+  bookingRecord: Record<string, any>,
+  smokeTest?: boolean
+): Promise<void> {
+  try {
+    const { createBookingCalendarEvent } = await import('@/lib/services/google-calendar');
+    const pickupDateTime = bookingRecord.trip?.pickupDateTime || bookingRecord.pickupDateTime || new Date();
+    const tripData = bookingRecord.trip || {
+      pickup: { address: bookingRecord.pickupLocation || '' },
+      dropoff: { address: bookingRecord.dropoffLocation || '' },
+      pickupDateTime,
+    };
+    const customerData = bookingRecord.customer || {
+      name: bookingRecord.name || '',
+      email: bookingRecord.email || '',
+    };
+
+    const calendarEventId = await createBookingCalendarEvent(
+      { id: bookingId, trip: tripData, customer: customerData },
+      { smokeTest, pending: true }
+    );
+
+    if (calendarEventId) {
+      const db = getAdminDb();
+      await db.collection('bookings').doc(bookingId).update({
+        calendarEventId,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    }
+  } catch (calendarError) {
+    console.error(`Failed to create tentative calendar event for booking ${bookingId} (non-blocking):`, calendarError);
+  }
 }
 
 async function ensureConfirmationToken(
@@ -283,6 +321,8 @@ export async function submitBookingOrchestration(
       throw new Error('Booking was created but could not be retrieved');
     }
 
+    await createTentativeCalendarEventForBooking(bookingResult.bookingId, bookingRecord);
+
     const confirmationUrlBase =
       process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
     const confirmationUrl = `${confirmationUrlBase}/booking/confirm?bookingId=${bookingResult.bookingId}&token=${resolvedConfirmationToken}`;
@@ -336,6 +376,7 @@ export async function submitBookingOrchestration(
     return {
       success: true,
       bookingId: bookingResult.bookingId,
+      trackingToken: bookingDataWithConfirmation.trackingToken,
       totalFare: fare,
       message: 'Booking created successfully — pending email confirmation',
       emailWarning,
@@ -451,6 +492,8 @@ export async function createPaidBookingAndNotify(
 
     const bookingRecord = await getBooking(bookingResult.bookingId);
     if (bookingRecord) {
+      await createTentativeCalendarEventForBooking(bookingResult.bookingId, bookingRecord, smokeTest);
+
       const confirmationUrlBase =
         process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
       const confirmationUrl = `${confirmationUrlBase}/booking/confirm?bookingId=${bookingResult.bookingId}&token=${confirmationToken}`;

--- a/src/lib/services/booking-orchestrator.ts
+++ b/src/lib/services/booking-orchestrator.ts
@@ -139,20 +139,11 @@ async function createTentativeCalendarEventForBooking(
   smokeTest?: boolean
 ): Promise<void> {
   try {
-    const { createBookingCalendarEvent } = await import('@/lib/services/google-calendar');
-    const pickupDateTime = bookingRecord.trip?.pickupDateTime || bookingRecord.pickupDateTime || new Date();
-    const tripData = bookingRecord.trip || {
-      pickup: { address: bookingRecord.pickupLocation || '' },
-      dropoff: { address: bookingRecord.dropoffLocation || '' },
-      pickupDateTime,
-    };
-    const customerData = bookingRecord.customer || {
-      name: bookingRecord.name || '',
-      email: bookingRecord.email || '',
-    };
+    const { createBookingCalendarEvent, toCalendarBookingInput } = await import('@/lib/services/google-calendar');
+    const calendarBookingInput = toCalendarBookingInput(bookingId, bookingRecord);
 
     const calendarEventId = await createBookingCalendarEvent(
-      { id: bookingId, trip: tripData, customer: customerData },
+      calendarBookingInput,
       { smokeTest, pending: true }
     );
 

--- a/src/lib/services/google-calendar.ts
+++ b/src/lib/services/google-calendar.ts
@@ -2,6 +2,10 @@
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { Client, TrafficModel } from '@googlemaps/google-maps-services-js';
+import { getAdminDb } from '@/lib/utils/firebase-admin';
+
+const CALENDAR_TOKENS_COLLECTION = 'systemConfig';
+const CALENDAR_TOKENS_DOC = 'googleCalendarTokens';
 
 // Google Calendar API configuration
 const CALENDAR_ID = process.env.GOOGLE_CALENDAR_ID || 'primary';
@@ -395,14 +399,16 @@ export const createBookingEvent = async (
   }
 };
 
-// Update an existing calendar event
+// Update an existing calendar event. Uses events.patch (not events.update) since `updates` is
+// a Partial<CalendarEvent> — events.update does not support patch semantics and replaces the
+// entire event resource, which would drop any field not included in `updates` (e.g. start/end).
 export const updateBookingEvent = async (
   calendar: any,
   eventId: string,
   updates: Partial<CalendarEvent>
 ): Promise<CalendarEvent> => {
   try {
-    const response = await calendar.events.update({
+    const response = await calendar.events.patch({
       calendarId: CALENDAR_ID,
       eventId: eventId,
       resource: updates,
@@ -459,18 +465,27 @@ export const getTokens = async (
   }
 };
 
-// Get stored calendar tokens (from environment or database)
-// TODO: Implement secure token storage in database
+// Persist OAuth tokens server-side (Firestore) so they survive across requests/deploys
+export const storeCalendarTokens = async (tokens: any): Promise<void> => {
+  const db = getAdminDb();
+  await db.collection(CALENDAR_TOKENS_COLLECTION).doc(CALENDAR_TOKENS_DOC).set({
+    tokens,
+    updatedAt: new Date().toISOString(),
+  });
+};
+
+// Get stored calendar tokens (env var takes precedence, falls back to Firestore)
 export const getStoredCalendarTokens = async (): Promise<any | null> => {
   try {
-    // Check environment variable first (for server-side operations)
+    // Check environment variable first (for server-side operations / local overrides)
     if (process.env.GOOGLE_CALENDAR_TOKENS) {
       return JSON.parse(process.env.GOOGLE_CALENDAR_TOKENS);
     }
-    
-    // TODO: Fetch from secure database storage
-    // For now, return null if not in environment
-    return null;
+
+    const db = getAdminDb();
+    const doc = await db.collection(CALENDAR_TOKENS_COLLECTION).doc(CALENDAR_TOKENS_DOC).get();
+    const data = doc.exists ? doc.data() : null;
+    return data?.tokens ?? null;
   } catch (error) {
     console.error('Error getting stored calendar tokens:', error);
     return null;
@@ -492,7 +507,7 @@ export const createBookingCalendarEvent = async (
       email: string;
     };
   },
-  options?: { smokeTest?: boolean }
+  options?: { smokeTest?: boolean; pending?: boolean }
 ): Promise<string | null> => {
   try {
     // Skip calendar operations in smoke test mode
@@ -522,9 +537,10 @@ export const createBookingCalendarEvent = async (
     const endTime = new Date(pickupTime);
     endTime.setHours(endTime.getHours() + 2); // Assume 2 hour duration
 
+    const isPending = options?.pending === true;
     const event = await createBookingEvent(calendar, {
-      summary: `Ride: ${booking.customer.name}`,
-      description: `Booking ID: ${booking.id}\nPickup: ${booking.trip.pickup.address}\nDropoff: ${booking.trip.dropoff.address}`,
+      summary: `${isPending ? '⏳ PENDING — ' : ''}Ride: ${booking.customer.name}`,
+      description: `${isPending ? 'AWAITING CUSTOMER CONFIRMATION — this slot is held tentatively. If the customer never confirms, cancel it manually from the admin dashboard to free the slot.\n\n' : ''}Booking ID: ${booking.id}\nPickup: ${booking.trip.pickup.address}\nDropoff: ${booking.trip.dropoff.address}`,
       startTime: pickupTime,
       endTime: endTime,
       customerEmail: booking.customer.email,
@@ -534,7 +550,7 @@ export const createBookingCalendarEvent = async (
     });
 
     if (event.id) {
-      console.log(`✅ Created calendar event ${event.id} for booking ${booking.id}`);
+      console.log(`✅ Created ${isPending ? 'tentative ' : ''}calendar event ${event.id} for booking ${booking.id}`);
       return event.id;
     }
 
@@ -543,5 +559,52 @@ export const createBookingCalendarEvent = async (
     console.error(`Failed to create calendar event for booking ${booking.id}:`, error);
     // Don't throw - calendar event creation failure shouldn't break booking
     return null;
+  }
+};
+
+// Remove the tentative "PENDING" marker from an existing calendar event once the
+// customer confirms. Non-throwing: calendar sync failures must never block confirmation.
+export const confirmBookingCalendarEvent = async (
+  eventId: string,
+  booking: {
+    id: string;
+    trip: {
+      pickup: { address: string };
+      dropoff: { address: string };
+    };
+    customer: {
+      name: string;
+    };
+  },
+  options?: { smokeTest?: boolean }
+): Promise<void> => {
+  try {
+    const isSmokeTest = options?.smokeTest || process.env.SMOKE_TEST_MODE === 'true';
+    if (isSmokeTest) {
+      console.log(`🧪 Smoke test mode - skipping calendar event confirmation for booking ${booking.id}`);
+      return;
+    }
+
+    const calendarIntegrationEnabled = process.env.ENABLE_GOOGLE_CALENDAR === 'true';
+    if (!calendarIntegrationEnabled) return;
+
+    const tokens = await getStoredCalendarTokens();
+    if (!tokens) {
+      console.warn('Calendar tokens not available - cannot update event for booking', booking.id);
+      return;
+    }
+
+    const oauth2Client = createOAuth2Client();
+    setCredentials(oauth2Client, tokens);
+    const calendar = initializeCalendarAPI(oauth2Client);
+
+    await updateBookingEvent(calendar, eventId, {
+      summary: `Ride: ${booking.customer.name}`,
+      description: `Booking ID: ${booking.id}\nPickup: ${booking.trip.pickup.address}\nDropoff: ${booking.trip.dropoff.address}`,
+    });
+
+    console.log(`✅ Cleared PENDING marker on calendar event ${eventId} for booking ${booking.id}`);
+  } catch (error) {
+    console.error(`Failed to update calendar event for booking ${booking.id}:`, error);
   }
 };

--- a/src/lib/services/google-calendar.ts
+++ b/src/lib/services/google-calendar.ts
@@ -11,6 +11,48 @@ const CALENDAR_TOKENS_DOC = 'googleCalendarTokens';
 const CALENDAR_ID = process.env.GOOGLE_CALENDAR_ID || 'primary';
 const SCOPES = ['https://www.googleapis.com/auth/calendar'];
 
+export interface CalendarBookingInput {
+  id: string;
+  trip: {
+    pickup: { address: string };
+    dropoff: { address: string };
+    pickupDateTime: Date | string;
+  };
+  customer: {
+    name: string;
+    email: string;
+  };
+}
+
+// Normalizes a raw Firestore booking record (as returned by getBooking(), where
+// bookingRecord.trip.pickupDateTime is still an un-normalized Firestore Timestamp) into the
+// shape createBookingCalendarEvent/confirmBookingCalendarEvent expect. Building `new Date(...)`
+// directly from a Timestamp object produces an Invalid Date, so this always normalizes it —
+// unlike `bookingRecord.trip || fallback`, which never applies a fallback once trip exists.
+export function toCalendarBookingInput(bookingId: string, bookingRecord: Record<string, any>): CalendarBookingInput {
+  const rawPickupDateTime =
+    bookingRecord?.trip?.pickupDateTime ?? bookingRecord?.pickupDateTime ?? new Date();
+  const pickupDateTime =
+    rawPickupDateTime instanceof Date
+      ? rawPickupDateTime
+      : typeof rawPickupDateTime?.toDate === 'function'
+        ? rawPickupDateTime.toDate()
+        : new Date(rawPickupDateTime);
+
+  return {
+    id: bookingId,
+    trip: {
+      pickup: { address: bookingRecord?.trip?.pickup?.address || bookingRecord?.pickupLocation || '' },
+      dropoff: { address: bookingRecord?.trip?.dropoff?.address || bookingRecord?.dropoffLocation || '' },
+      pickupDateTime,
+    },
+    customer: {
+      name: bookingRecord?.customer?.name || bookingRecord?.name || '',
+      email: bookingRecord?.customer?.email || bookingRecord?.email || '',
+    },
+  };
+}
+
 const mapsClient = new Client({});
 const DRIVER_HOME_BASE = process.env.DRIVER_HOME_BASE || 'Newtown, CT';
 const DEFAULT_LOOKBACK_MINUTES = 240; // 4 hours
@@ -495,18 +537,7 @@ export const getStoredCalendarTokens = async (): Promise<any | null> => {
 // Create calendar event for a booking and return event ID
 // This is used server-side when bookings are confirmed
 export const createBookingCalendarEvent = async (
-  booking: {
-    id: string;
-    trip: {
-      pickup: { address: string };
-      dropoff: { address: string };
-      pickupDateTime: Date | string;
-    };
-    customer: {
-      name: string;
-      email: string;
-    };
-  },
+  booking: CalendarBookingInput,
   options?: { smokeTest?: boolean; pending?: boolean }
 ): Promise<string | null> => {
   try {
@@ -562,20 +593,13 @@ export const createBookingCalendarEvent = async (
   }
 };
 
-// Remove the tentative "PENDING" marker from an existing calendar event once the
-// customer confirms. Non-throwing: calendar sync failures must never block confirmation.
+// Remove the tentative "PENDING" marker from an existing calendar event once the customer
+// confirms, and re-sync start/end/location in case the booking was edited (pickup/dropoff/time)
+// between submission and confirmation. Non-throwing: calendar sync failures must never block
+// confirmation.
 export const confirmBookingCalendarEvent = async (
   eventId: string,
-  booking: {
-    id: string;
-    trip: {
-      pickup: { address: string };
-      dropoff: { address: string };
-    };
-    customer: {
-      name: string;
-    };
-  },
+  booking: CalendarBookingInput,
   options?: { smokeTest?: boolean }
 ): Promise<void> => {
   try {
@@ -598,12 +622,19 @@ export const confirmBookingCalendarEvent = async (
     setCredentials(oauth2Client, tokens);
     const calendar = initializeCalendarAPI(oauth2Client);
 
+    const pickupTime = new Date(booking.trip.pickupDateTime);
+    const endTime = new Date(pickupTime);
+    endTime.setHours(endTime.getHours() + 2);
+
     await updateBookingEvent(calendar, eventId, {
       summary: `Ride: ${booking.customer.name}`,
       description: `Booking ID: ${booking.id}\nPickup: ${booking.trip.pickup.address}\nDropoff: ${booking.trip.dropoff.address}`,
+      start: { dateTime: pickupTime.toISOString(), timeZone: 'America/New_York' },
+      end: { dateTime: endTime.toISOString(), timeZone: 'America/New_York' },
+      location: `${booking.trip.pickup.address} → ${booking.trip.dropoff.address}`,
     });
 
-    console.log(`✅ Cleared PENDING marker on calendar event ${eventId} for booking ${booking.id}`);
+    console.log(`✅ Cleared PENDING marker and synced timing on calendar event ${eventId} for booking ${booking.id}`);
   } catch (error) {
     console.error(`Failed to update calendar event for booking ${booking.id}:`, error);
   }

--- a/src/providers/BookingProvider.tsx
+++ b/src/providers/BookingProvider.tsx
@@ -43,6 +43,7 @@ const [isSubmitting, setIsSubmitting] = useState(false);
 const [success, setSuccess] = useState<string | null>(null);
 const [warning, setWarning] = useState<string | null>(null);
   const [completedBookingId, setCompletedBookingId] = useState<string | null>(null);
+  const [completedTrackingToken, setCompletedTrackingToken] = useState<string | null>(null);
   const [currentQuote, setCurrentQuote] = useState<QuoteData | null>(null);
 
   useEffect(() => {
@@ -186,6 +187,8 @@ const [warning, setWarning] = useState<string | null>(null);
     existingBooking,
     formData,
     currentQuote,
+    completedBookingId,
+    completedTrackingToken,
     validatePhaseWithApi,
     validateCurrentPhase,
     createBooking,
@@ -201,6 +204,7 @@ const [warning, setWarning] = useState<string | null>(null);
     setSuccess,
     setHasAttemptedValidation,
     setCompletedBookingId,
+    setCompletedTrackingToken,
   });
 
   // Compute validation reactively

--- a/src/providers/booking/booking-api-client.ts
+++ b/src/providers/booking/booking-api-client.ts
@@ -72,8 +72,11 @@ export async function createBookingRequest(data: Partial<Booking>): Promise<Book
   } as Booking;
 }
 
-export async function updateBookingRequest(id: string, data: Partial<Booking>): Promise<Booking> {
-  const response = await authFetch(`/api/booking/${id}`, {
+export async function updateBookingRequest(id: string, data: Partial<Booking>, trackingToken?: string): Promise<Booking> {
+  const url = trackingToken
+    ? `/api/booking/${id}?token=${encodeURIComponent(trackingToken)}`
+    : `/api/booking/${id}`;
+  const response = await authFetch(url, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/src/providers/booking/provider-actions-factory.ts
+++ b/src/providers/booking/provider-actions-factory.ts
@@ -14,10 +14,12 @@ interface CreateBookingProviderActionsParams {
   existingBooking?: Booking;
   formData: any;
   currentQuote: QuoteData | null;
+  completedBookingId: string | null;
+  completedTrackingToken: string | null;
   validatePhaseWithApi: (_phase: 'trip-details' | 'contact-info' | 'payment' | 'quick-booking', _options?: { skipQuoteRequirement?: boolean }) => Promise<ValidationResult>;
   validateCurrentPhase: () => ValidationResult;
   createBooking: (_data: Partial<Booking>) => Promise<Booking>;
-  updateBooking: (_id: string, _data: Partial<Booking>) => Promise<Booking>;
+  updateBooking: (_id: string, _data: Partial<Booking>, _trackingToken?: string) => Promise<Booking>;
   resetFormData: () => void;
   clearStoredFormData: () => void;
   clearAllApiValidation: () => void;
@@ -29,6 +31,7 @@ interface CreateBookingProviderActionsParams {
   setSuccess: (_value: string | null) => void;
   setHasAttemptedValidation: (_value: boolean) => void;
   setCompletedBookingId: (_value: string | null) => void;
+  setCompletedTrackingToken: (_value: string | null) => void;
 }
 
 export function createBookingProviderActions(params: CreateBookingProviderActionsParams) {
@@ -38,6 +41,8 @@ export function createBookingProviderActions(params: CreateBookingProviderAction
     existingBooking,
     formData,
     currentQuote,
+    completedBookingId,
+    completedTrackingToken,
     validatePhaseWithApi,
     validateCurrentPhase,
     createBooking,
@@ -53,6 +58,7 @@ export function createBookingProviderActions(params: CreateBookingProviderAction
     setSuccess,
     setHasAttemptedValidation,
     setCompletedBookingId,
+    setCompletedTrackingToken,
   } = params;
 
   const clearAllErrors = () => {
@@ -97,6 +103,7 @@ export function createBookingProviderActions(params: CreateBookingProviderAction
       setSuccess,
       setHasAttemptedValidation,
       setCompletedBookingId,
+      setCompletedTrackingToken,
       setCurrentPhase,
     });
 
@@ -123,8 +130,26 @@ export function createBookingProviderActions(params: CreateBookingProviderAction
     });
   };
 
-  const completeFlightInfo = () => {
-    setSuccess('Booking submitted — confirm via email.');
+  const completeFlightInfo = async () => {
+    if (!completedBookingId) {
+      setError('Could not save flight info — booking ID is missing. Please text us your flight number at (203) 990-1815.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await updateBooking(
+        completedBookingId,
+        { flightInfo: formData.trip.flightInfo } as Partial<Booking>,
+        completedTrackingToken ?? undefined
+      );
+      setError(null);
+      setSuccess('Booking submitted — confirm via email.');
+    } catch {
+      setError('We could not save your flight info. Please text us your flight number at (203) 990-1815.');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return {

--- a/src/providers/booking/submission.ts
+++ b/src/providers/booking/submission.ts
@@ -26,6 +26,7 @@ interface SubmitBookingParams {
   setSuccess: (_value: string | null) => void;
   setHasAttemptedValidation: (_value: boolean) => void;
   setCompletedBookingId: (_value: string | null) => void;
+  setCompletedTrackingToken: (_value: string | null) => void;
   setCurrentPhase: (_phase: BookingPhase) => void;
 }
 
@@ -90,6 +91,7 @@ export async function submitBookingFlow(params: SubmitBookingParams): Promise<{ 
     setSuccess,
     setHasAttemptedValidation,
     setCompletedBookingId,
+    setCompletedTrackingToken,
     setCurrentPhase,
   } = params;
 
@@ -168,6 +170,7 @@ export async function submitBookingFlow(params: SubmitBookingParams): Promise<{ 
 
     const responseData = await res.json();
     setCompletedBookingId(responseData.bookingId || null);
+    setCompletedTrackingToken(responseData.trackingToken || null);
     if (responseData.emailWarning) {
       setWarning(responseData.emailWarning);
     }

--- a/src/providers/booking/use-booking-crud.ts
+++ b/src/providers/booking/use-booking-crud.ts
@@ -34,12 +34,12 @@ export function useBookingCrud(params: UseBookingCrudParams) {
     }
   }, [setError]);
 
-  const updateBooking = useCallback(async (id: string, data: Partial<Booking>): Promise<Booking> => {
+  const updateBooking = useCallback(async (id: string, data: Partial<Booking>, trackingToken?: string): Promise<Booking> => {
     setIsLoading(true);
     setError(null);
 
     try {
-      const booking = await updateBookingRequest(id, data);
+      const booking = await updateBookingRequest(id, data, trackingToken);
       setCurrentBooking(booking);
       return booking;
     } catch (err) {

--- a/tests/integration/api-sdk-usage.test.ts
+++ b/tests/integration/api-sdk-usage.test.ts
@@ -10,6 +10,11 @@ const sendConfirmationEmail = vi.fn().mockResolvedValue(undefined);
 const adaptOldBookingToNew = vi.fn((booking) => booking);
 const createBookingCalendarEvent = vi.fn().mockResolvedValue(null);
 const confirmBookingCalendarEvent = vi.fn().mockResolvedValue(undefined);
+const toCalendarBookingInput = vi.fn((bookingId: string, bookingRecord: any) => ({
+  id: bookingId,
+  trip: bookingRecord.trip,
+  customer: bookingRecord.customer,
+}));
 
 vi.mock('@/lib/utils/firebase-admin', () => ({
   getAdminDb,
@@ -37,6 +42,7 @@ vi.mock('@/utils/bookingAdapter', () => ({
 vi.mock('@/lib/services/google-calendar', () => ({
   createBookingCalendarEvent,
   confirmBookingCalendarEvent,
+  toCalendarBookingInput,
 }));
 
 function makeNextRequest(url: string, init?: RequestInit): Request {

--- a/tests/integration/api-sdk-usage.test.ts
+++ b/tests/integration/api-sdk-usage.test.ts
@@ -9,6 +9,7 @@ const getBooking = vi.fn();
 const sendConfirmationEmail = vi.fn().mockResolvedValue(undefined);
 const adaptOldBookingToNew = vi.fn((booking) => booking);
 const createBookingCalendarEvent = vi.fn().mockResolvedValue(null);
+const confirmBookingCalendarEvent = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/lib/utils/firebase-admin', () => ({
   getAdminDb,
@@ -35,6 +36,7 @@ vi.mock('@/utils/bookingAdapter', () => ({
 
 vi.mock('@/lib/services/google-calendar', () => ({
   createBookingCalendarEvent,
+  confirmBookingCalendarEvent,
 }));
 
 function makeNextRequest(url: string, init?: RequestInit): Request {

--- a/tests/integration/booking-api-endpoints.test.ts
+++ b/tests/integration/booking-api-endpoints.test.ts
@@ -367,4 +367,126 @@ describe('Booking API Endpoints - Deterministic Integration', () => {
       expect(getAvailableDriversForTimeSlot).toHaveBeenCalledWith('2026-03-05', '10:00', '12:00');
     });
   });
+
+  describe('PUT /api/booking/[bookingId] — tracking-token flight-info flow (guest, no Firebase session)', () => {
+    const existingFlightInfo = { hasFlight: false, airline: '', flightNumber: '', arrivalTime: '', terminal: '' };
+    const baseBookingData = {
+      status: 'pending',
+      trackingToken: 'track-abc',
+      trip: {
+        pickup: { address: '123 Main St', coordinates: null },
+        dropoff: { address: 'JFK', coordinates: null },
+        pickupDateTime: makeTimestamp('2026-04-01T10:00:00.000Z'),
+        flightInfo: existingFlightInfo,
+      },
+      customer: { name: 'Test Rider', email: 'rider@example.com', phone: '+12035551234' },
+      createdAt: makeTimestamp('2026-03-01T00:00:00.000Z'),
+      updatedAt: makeTimestamp('2026-03-01T00:00:00.000Z'),
+    };
+
+    const mockBookingDb = () => {
+      const docUpdate = vi.fn().mockResolvedValue(undefined);
+      const docGet = vi.fn().mockResolvedValue({ exists: true, id: 'booking-1', data: () => baseBookingData });
+      getAdminDb.mockReturnValue({
+        collection: vi.fn(() => ({
+          doc: vi.fn(() => ({
+            get: docGet,
+            update: docUpdate,
+          })),
+        })),
+      });
+      return { docUpdate, docGet };
+    };
+
+    it('allows tracking-token access to save flight info', async () => {
+      requireOwnerAdminOrTrackingToken.mockResolvedValue({ ok: true, auth: null, access: 'tracking-token' });
+      const { docUpdate } = mockBookingDb();
+
+      const { PUT } = await import('@/app/api/booking/[bookingId]/route');
+      const response = ensureResponse(
+        await PUT(
+          makeNextRequest('http://localhost/api/booking/booking-1?token=track-abc', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              flightInfo: { hasFlight: true, airline: 'Delta', flightNumber: 'DL123', arrivalTime: '', terminal: '4' },
+            }),
+          }) as any,
+          { params: Promise.resolve({ bookingId: 'booking-1' }) }
+        )
+      );
+
+      expect(response.status).toBe(200);
+      expect(docUpdate).toHaveBeenCalled();
+      const updatePayload = docUpdate.mock.calls[0][0] as any;
+      expect(updatePayload.trip.flightInfo.flightNumber).toBe('DL123');
+      expect(updatePayload.flightNumber).toBe('DL123');
+      const body = await response.json();
+      expect(body.changedFields).toContain('flight info');
+    });
+
+    it('rejects tracking-token access trying to change fields other than flightInfo', async () => {
+      requireOwnerAdminOrTrackingToken.mockResolvedValue({ ok: true, auth: null, access: 'tracking-token' });
+      const { docUpdate } = mockBookingDb();
+
+      const { PUT } = await import('@/app/api/booking/[bookingId]/route');
+      const response = ensureResponse(
+        await PUT(
+          makeNextRequest('http://localhost/api/booking/booking-1?token=track-abc', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ customer: { name: 'Hacked Name' } }),
+          }) as any,
+          { params: Promise.resolve({ bookingId: 'booking-1' }) }
+        )
+      );
+
+      expect(response.status).toBe(403);
+      expect(docUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does not report a change (and skips the admin SMS trigger) when flight info is unchanged', async () => {
+      requireOwnerAdminOrTrackingToken.mockResolvedValue({ ok: true, auth: null, access: 'tracking-token' });
+      mockBookingDb();
+
+      const { PUT } = await import('@/app/api/booking/[bookingId]/route');
+      const response = ensureResponse(
+        await PUT(
+          makeNextRequest('http://localhost/api/booking/booking-1?token=track-abc', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ flightInfo: existingFlightInfo }),
+          }) as any,
+          { params: Promise.resolve({ bookingId: 'booking-1' }) }
+        )
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.changedFields).toEqual([]);
+    });
+
+    it('rejects a request with no valid access (no session, no tracking token)', async () => {
+      requireOwnerAdminOrTrackingToken.mockResolvedValue({
+        ok: false,
+        response: new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+      });
+      const { docUpdate } = mockBookingDb();
+
+      const { PUT } = await import('@/app/api/booking/[bookingId]/route');
+      const response = ensureResponse(
+        await PUT(
+          makeNextRequest('http://localhost/api/booking/booking-1', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ flightInfo: { hasFlight: true, airline: 'Delta', flightNumber: 'DL123', arrivalTime: '', terminal: '4' } }),
+          }) as any,
+          { params: Promise.resolve({ bookingId: 'booking-1' }) }
+        )
+      );
+
+      expect(response.status).toBe(401);
+      expect(docUpdate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/unit/booking-submission-flow.test.ts
+++ b/tests/unit/booking-submission-flow.test.ts
@@ -73,6 +73,7 @@ describe('submitBookingFlow time serialization', () => {
       setSuccess: vi.fn(),
       setHasAttemptedValidation: vi.fn(),
       setCompletedBookingId: vi.fn(),
+      setCompletedTrackingToken: vi.fn(),
       setCurrentPhase: vi.fn(),
     });
 
@@ -99,6 +100,7 @@ describe('submitBookingFlow time serialization', () => {
       setSuccess: vi.fn(),
       setHasAttemptedValidation: vi.fn(),
       setCompletedBookingId: vi.fn(),
+      setCompletedTrackingToken: vi.fn(),
       setCurrentPhase: vi.fn(),
     });
 
@@ -124,6 +126,7 @@ describe('submitBookingFlow time serialization', () => {
       setSuccess: vi.fn(),
       setHasAttemptedValidation: vi.fn(),
       setCompletedBookingId: vi.fn(),
+      setCompletedTrackingToken: vi.fn(),
       setCurrentPhase: vi.fn(),
     });
 


### PR DESCRIPTION
## Summary
- Flight numbers were captured on a post-submit phase whose "Save" button never called any API — it only faked a success message. Now it actually persists via a scoped tracking-token PUT (guest customers have no Firebase session at that point in the flow), stops spamming an admin SMS on every single booking, and guards against double-submit.
- New bookings didn't appear on the Google Calendar because an event was only ever created after email confirmation, and OAuth tokens were never persisted anywhere (a `TODO` left unimplemented). Now a tentative event is created at booking-submission time, marked `⏳ PENDING —` until the customer confirms. Nothing here is automated — cancelling still requires clicking the existing admin "Cancel" button, which already deletes the calendar event.
- Tokens now persist to Firestore instead of only an env var, so the calendar connection survives across requests/deploys. Wired the previously-orphaned "Connect Google Calendar" component into `/admin/settings`.
- Full self-review (8-angle pass) surfaced and fixed 5 correctness issues before this was pushed, most notably: the flight-info PUT would have 401'd for unauthenticated guest bookers, and the calendar "clear PENDING marker" update was using full-replace semantics that could have wiped the event's start/end.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` on all touched files — 0 errors (pre-existing `any`/style warnings only)
- [x] `npm run test:unit` (booking-submission-flow suite) — 3/3 pass
- [x] `npm run test:integration` — 115/115 pass (1 mock updated for the new `confirmBookingCalendarEvent` export)
- [x] `npm run build` — succeeds, all routes compile
- [ ] Manual: connect Google Calendar via `/admin/settings` in a deployed environment and verify a real booking creates a PENDING event, confirming clears the marker, and cancelling deletes it
- [ ] Manual: submit a booking as a logged-out guest and confirm the flight-info save succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)