### PR TITLE
Fix: remove client-controlled smoke-test header bypass on payment/calendar routes

### DIFF
--- a/src/app/api/booking/confirm/route.ts
+++ b/src/app/api/booking/confirm/route.ts
@@ -9,9 +9,8 @@ export async function POST(request: NextRequest) {
   try {
     const { bookingId, token } = await request.json();
 
-    // Check for smoke test mode
-    const smokeTestHeader = request.headers.get('x-smoke-test');
-    const isSmokeTest = smokeTestHeader === 'true' || process.env.SMOKE_TEST_MODE === 'true';
+    // Smoke test mode is a server-only env flag — never derived from a client-supplied header.
+    const isSmokeTest = process.env.SMOKE_TEST_MODE === 'true';
 
     if (!bookingId || !token) {
       return NextResponse.json(

--- a/src/app/api/calendar/verify-delete/route.ts
+++ b/src/app/api/calendar/verify-delete/route.ts
@@ -12,10 +12,11 @@ const CALENDAR_ID = process.env.GOOGLE_CALENDAR_ID || 'primary';
 
 export async function GET(request: NextRequest) {
   try {
-    // Only allow in smoke test mode
-    const isSmokeTest = request.headers.get('x-smoke-test') === 'true' || 
-                       process.env.SMOKE_TEST_MODE === 'true';
-    
+    // Smoke test mode is a server-only env flag — never derived from a client-supplied header,
+    // since that would let anyone use this endpoint to probe booking existence and trigger live
+    // Google Calendar API calls.
+    const isSmokeTest = process.env.SMOKE_TEST_MODE === 'true';
+
     if (!isSmokeTest) {
       return NextResponse.json({ error: 'Unauthorized - smoke test only' }, { status: 401 });
     }

--- a/src/app/api/payment/process-payment/route.ts
+++ b/src/app/api/payment/process-payment/route.ts
@@ -42,9 +42,9 @@ export async function POST(request: Request) {
     bookingData = bd;
     const authContext = await getAuthContext(request);
 
-    // Check for smoke test mode
-    const smokeTestHeader = request.headers.get('x-smoke-test');
-    const isSmokeTest = smokeTestHeader === 'true' || process.env.SMOKE_TEST_MODE === 'true';
+    // Smoke test mode is a server-only env flag — never derived from a client-supplied header,
+    // since that would let anyone skip real payment processing on a live deployment.
+    const isSmokeTest = process.env.SMOKE_TEST_MODE === 'true';
 
     if (!paymentToken || !amount || !currency) {
       return NextResponse.json({ 

--- a/tests/integration/api-sdk-usage.test.ts
+++ b/tests/integration/api-sdk-usage.test.ts
@@ -272,7 +272,7 @@ describe('API access and confirmation flow', () => {
         await POST(
           makeNextRequest('http://localhost/api/booking/confirm', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'x-smoke-test': 'true' },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ bookingId: 'booking-1', token: 'expected-token' }),
           }) as any
         )

--- a/tests/unit/process-payment.route.test.ts
+++ b/tests/unit/process-payment.route.test.ts
@@ -172,6 +172,65 @@ describe('POST /api/payment/process-payment', () => {
     });
   });
 
+  it('ignores a client-supplied x-smoke-test header — real payment still runs (regression: header used to bypass Square entirely)', async () => {
+    mockProcessPayment.mockResolvedValueOnce({
+      success: true,
+      orderId: 'order-real',
+      paymentId: 'pay-real',
+      status: 'COMPLETED',
+      amount: 15000,
+      currency: 'USD',
+    });
+    mockCreateBookingAtomic.mockResolvedValueOnce({ bookingId: 'booking-real' });
+    mockGetBooking.mockResolvedValueOnce({
+      id: 'booking-real',
+      trip: {
+        pickup: baseRequestBody.bookingData.trip.pickup,
+        dropoff: baseRequestBody.bookingData.trip.dropoff,
+        pickupDateTime: baseRequestBody.bookingData.trip.pickupDateTime,
+        fareType: baseRequestBody.bookingData.trip.fareType,
+        flightInfo: baseRequestBody.bookingData.trip.flightInfo,
+      },
+      customer: {
+        name: baseRequestBody.bookingData.customer.name,
+        email: baseRequestBody.bookingData.customer.email,
+        phone: baseRequestBody.bookingData.customer.phone,
+        notes: baseRequestBody.bookingData.customer.notes,
+        saveInfoForFuture: baseRequestBody.bookingData.customer.saveInfoForFuture,
+      },
+      payment: {
+        tipAmount: baseRequestBody.bookingData.payment.tipAmount,
+        tipPercent: 0,
+        balanceDue: 0,
+        depositAmount: 150,
+        depositPaid: true,
+        totalAmount: baseRequestBody.bookingData.payment.totalAmount,
+      },
+      status: 'pending',
+    });
+    mockSendBookingVerificationEmail.mockResolvedValueOnce(undefined);
+    mockSendSms.mockResolvedValueOnce(undefined);
+
+    const request = new Request('http://localhost/api/payment/process-payment', {
+      method: 'POST',
+      body: JSON.stringify(baseRequestBody),
+      headers: {
+        'Content-Type': 'application/json',
+        // An attacker-controlled header. Must NOT put the route into smoke-test mode —
+        // only process.env.SMOKE_TEST_MODE may do that.
+        'x-smoke-test': 'true',
+      },
+    });
+
+    const response = await POST(request);
+    const payload = await response!.json();
+
+    expect(response!.status).toBe(200);
+    expect(mockProcessPayment).toHaveBeenCalledTimes(1);
+    expect(mockProcessPayment).toHaveBeenCalledWith('tok_test', 15000, 'USD', 'temp-booking-id');
+    expect(payload.paymentId).toBe('pay-real');
+  });
+
   it('returns 400 when amount is not an integer (must be cents)', async () => {
     const response = await POST(buildRequest({ ...baseRequestBody, amount: 150.5 }));
     const payload = await response!.json();


### PR DESCRIPTION
## Summary

**Critical, pre-existing vulnerability** (unrelated to PR #36) — three routes derived "smoke test mode" from a client-supplied `x-smoke-test` request header, not just the server-side `SMOKE_TEST_MODE` env var:

- `/api/payment/process-payment` — an anonymous caller sending `x-smoke-test: true` skipped real Square payment processing entirely, while the route still created a real confirmed booking (`depositPaid: true`), reserved a real calendar slot, and sent a real confirmation SMS/email to whatever phone number/email the caller supplied. Concretely: free rides, calendar-slot squatting against real customers, and a harassment vector (spoofed booking-confirmation texts to a victim's phone) — all at the business's Twilio/Square/email expense.
- `/api/calendar/verify-delete` — no auth at all beyond the same header; let anyone probe whether a `bookingId` exists and trigger live Google Calendar API calls.
- `/api/booking/confirm` — same pattern, lower risk since it's already gated by a random confirmation token, but same anti-pattern.

## Why this is safe to fix by simply removing the header path

Checked every real caller: `scripts/smoke-test-production.mjs` (the actual production smoke-test job) never sends this header and never touches these three routes — it only hits `/api/health`, the homepage, `/api/booking/quote`, and `/api/health/booking-flow`. Grepped `tests/` and `scripts/` — the only place this header was ever used was our own integration test for `/api/booking/confirm`, updated in this PR to not need it. No legitimate functionality depended on the header.

## Fix

Removed `request.headers.get('x-smoke-test')` from all three routes. Smoke-test mode is now solely `process.env.SMOKE_TEST_MODE === 'true'` — a real server-only env flag no HTTP caller can set — matching the safe pattern already used elsewhere (`booking-cancellation.ts`, `google-calendar.ts`).

Added a regression test (`tests/unit/process-payment.route.test.ts`) asserting that a client-supplied `x-smoke-test: true` header no longer bypasses real payment processing.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` on touched files — 0 errors
- [x] Full unit + integration suite — 344 passed, 5 skipped, 0 failed
- [x] `npm run build` — succeeds
- [x] New regression test confirms the header is inert and `processPayment` still runs for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)