### PR TITLE
Fix: cancellation refund overcharge bug (raw Timestamp normalization)

### DIFF
--- a/src/app/api/booking/get-bookings-simple/route.ts
+++ b/src/app/api/booking/get-bookings-simple/route.ts
@@ -67,11 +67,16 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      // Convert Firestore timestamps and format booking
+      // Convert Firestore timestamps and format booking. `rawData.trip.pickupDateTime` is a raw
+      // Firestore Timestamp (never normalized by the spread below), and the flat top-level
+      // `pickupDateTime` is absent on every booking created through the normal submit flow — so
+      // both must be derived from whichever one actually has the value.
+      const normalizedPickupDateTime = safeToDate(rawData.pickupDateTime ?? rawData.trip?.pickupDateTime);
       const booking = {
         id: docSnap.id,
         ...rawData,
-        pickupDateTime: safeToDate(rawData.pickupDateTime),
+        ...(rawData.trip ? { trip: { ...rawData.trip, pickupDateTime: normalizedPickupDateTime ?? rawData.trip.pickupDateTime } } : {}),
+        pickupDateTime: normalizedPickupDateTime,
         createdAt: safeToDate(rawData.createdAt),
         updatedAt: safeToDate(rawData.updatedAt),
         confirmation: rawData.confirmation
@@ -115,10 +120,12 @@ export async function GET(request: NextRequest) {
 
       const bookings = snapshot.docs.map((docSnap: QueryDocumentSnapshot) => {
         const data = docSnap.data();
+        const normalizedPickupDateTime = safeToDate(data.pickupDateTime ?? data.trip?.pickupDateTime);
         return {
           id: docSnap.id,
           ...data,
-          pickupDateTime: safeToDate(data.pickupDateTime),
+          ...(data.trip ? { trip: { ...data.trip, pickupDateTime: normalizedPickupDateTime ?? data.trip.pickupDateTime } } : {}),
+          pickupDateTime: normalizedPickupDateTime,
           createdAt: safeToDate(data.createdAt),
           updatedAt: safeToDate(data.updatedAt),
           confirmation: data.confirmation

--- a/src/lib/services/booking-service.ts
+++ b/src/lib/services/booking-service.ts
@@ -298,13 +298,20 @@ export const getBooking = async (bookingId: string): Promise<Booking | null> => 
   }
   
   const data = bookingDoc.data();
-  
+
   const pickupDateTimeRaw = data?.trip?.pickupDateTime ?? data?.pickupDateTime;
+  const normalizedPickupDateTime = safeToOptionalDate(pickupDateTimeRaw);
 
   return {
     id: bookingDoc.id,
     ...data,
-    pickupDateTime: safeToOptionalDate(pickupDateTimeRaw),
+    // `...data` above carries the raw (un-normalized) Firestore Timestamp through on
+    // `data.trip.pickupDateTime` — override it here so callers reading either the nested
+    // `trip.pickupDateTime` or the flat `pickupDateTime` get the same normalized Date. Without
+    // this, `new Date(booking.trip.pickupDateTime)` on a raw Timestamp silently produces an
+    // Invalid Date (NaN on any arithmetic), which is exactly what caused this bug.
+    ...(data?.trip ? { trip: { ...data.trip, pickupDateTime: normalizedPickupDateTime ?? data.trip.pickupDateTime } } : {}),
+    pickupDateTime: normalizedPickupDateTime,
     createdAt: safeToDate(data?.createdAt),
     updatedAt: safeToDate(data?.updatedAt),
     confirmation: data?.confirmation
@@ -343,11 +350,13 @@ export const getBookings = async (
   return snapshot.docs.map((doc: any) => {
     const data = doc.data();
     const pickupDateTimeRaw = data?.trip?.pickupDateTime ?? data?.pickupDateTime;
-    
+    const normalizedPickupDateTime = safeToOptionalDate(pickupDateTimeRaw);
+
     return {
       id: doc.id,
       ...data,
-      pickupDateTime: safeToOptionalDate(pickupDateTimeRaw),
+      ...(data?.trip ? { trip: { ...data.trip, pickupDateTime: normalizedPickupDateTime ?? data.trip.pickupDateTime } } : {}),
+      pickupDateTime: normalizedPickupDateTime,
       createdAt: safeToDate(data?.createdAt),
       updatedAt: safeToDate(data?.updatedAt),
     };

--- a/src/lib/services/driver-scheduling-service.ts
+++ b/src/lib/services/driver-scheduling-service.ts
@@ -27,6 +27,15 @@ export interface DriverSchedule {
   updatedAt: Date;
 }
 
+// Firestore returns createdAt/updatedAt as raw Timestamps, not Date instances — this type
+// claims Date, so normalize at the read boundary rather than let a future caller do
+// `schedule.updatedAt.getTime()` on what's actually a Timestamp object.
+const normalizeScheduleDates = (raw: any): DriverSchedule => ({
+  ...raw,
+  createdAt: raw?.createdAt?.toDate ? raw.createdAt.toDate() : (raw?.createdAt instanceof Date ? raw.createdAt : new Date(raw?.createdAt ?? Date.now())),
+  updatedAt: raw?.updatedAt?.toDate ? raw.updatedAt.toDate() : (raw?.updatedAt instanceof Date ? raw.updatedAt : new Date(raw?.updatedAt ?? Date.now())),
+});
+
 export interface TimeSlot {
   id: string;
   startTime: string; // HH:MM format
@@ -528,19 +537,19 @@ export class DriverSchedulingService {
         const deterministic = await db.collection('driverSchedules').doc(scheduleDocId).get();
         if (deterministic.exists) {
           const deterministicData = deterministic.data() ?? {};
-          return {
+          return normalizeScheduleDates({
             id: deterministic.id,
             ...deterministicData
-          } as DriverSchedule;
+          });
         }
       } else {
         const deterministic = await getDoc(doc(db, 'driverSchedules', scheduleDocId));
         if (deterministic.exists()) {
           const deterministicData = deterministic.data() ?? {};
-          return {
+          return normalizeScheduleDates({
             id: deterministic.id,
             ...deterministicData
-          } as DriverSchedule;
+          });
         }
       }
 
@@ -567,10 +576,10 @@ export class DriverSchedulingService {
       }
 
       const scheduleDoc = scheduleSnapshot.docs[0];
-      return {
+      return normalizeScheduleDates({
         id: scheduleDoc.id,
         ...(scheduleDoc.data ? scheduleDoc.data() : scheduleDoc)
-      } as DriverSchedule;
+      });
     } catch (error) {
       console.error('Error getting driver schedule:', error);
       return null;
@@ -610,10 +619,10 @@ export class DriverSchedulingService {
       }
       
       const docs = scheduleSnapshot.docs || [];
-      return docs.map((doc: any) => ({
+      return docs.map((doc: any) => normalizeScheduleDates({
         id: doc.id,
         ...(doc.data ? doc.data() : doc)
-      })) as DriverSchedule[];
+      }));
     } catch (error) {
       console.error('Error getting driver schedules:', error);
       return [];

--- a/tests/unit/booking-service-timestamp-normalization.test.ts
+++ b/tests/unit/booking-service-timestamp-normalization.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getAdminDb = vi.fn();
+
+vi.mock('@/lib/utils/firebase-admin', () => ({
+  getAdminDb,
+}));
+
+vi.mock('@/lib/services/driver-service', () => ({
+  getDriver: vi.fn(),
+}));
+
+vi.mock('@/lib/services/driver-scheduling-service', () => ({
+  driverSchedulingService: {
+    checkBookingConflicts: vi.fn(),
+    getAvailableDriversForTimeSlot: vi.fn(),
+    getScheduleDocId: vi.fn(),
+    generateTimeSlots: vi.fn(() => []),
+  },
+}));
+
+vi.mock('@/utils/booking-id-generator', () => ({
+  generateShortBookingId: vi.fn(() => 'booking_123'),
+}));
+
+vi.mock('@/lib/services/booking-availability', () => ({
+  isTimeSlotAvailable: vi.fn(),
+  getAvailableDrivers: vi.fn(),
+}));
+
+vi.mock('@/lib/services/booking-cancellation', () => ({
+  cancelBooking: vi.fn(),
+}));
+
+// Mimics a real Firestore Timestamp: has a .toDate() method, is NOT a Date instance,
+// and new Date(timestamp) does NOT produce a valid date (which is the root cause
+// this regression test guards against).
+function fakeFirestoreTimestamp(iso: string) {
+  const date = new Date(iso);
+  return {
+    _seconds: Math.floor(date.getTime() / 1000),
+    _nanoseconds: 0,
+    toDate: () => date,
+  };
+}
+
+describe('getBooking / getBookings — Timestamp normalization', () => {
+  let getBooking: typeof import('@/lib/services/booking-service').getBooking;
+  let getBookings: typeof import('@/lib/services/booking-service').getBookings;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    ({ getBooking, getBookings } = await import('@/lib/services/booking-service'));
+  });
+
+  it('normalizes a raw Firestore Timestamp on trip.pickupDateTime into a real Date', async () => {
+    const pickupIso = '2026-08-01T14:00:00.000Z';
+    const rawBookingData = {
+      status: 'pending',
+      trip: {
+        pickup: { address: '123 Main St' },
+        dropoff: { address: 'JFK' },
+        pickupDateTime: fakeFirestoreTimestamp(pickupIso),
+      },
+      customer: { name: 'Jane Doe', email: 'jane@example.com' },
+      createdAt: fakeFirestoreTimestamp('2026-07-01T10:00:00.000Z'),
+      updatedAt: fakeFirestoreTimestamp('2026-07-01T10:00:00.000Z'),
+    };
+
+    getAdminDb.mockReturnValue({
+      collection: vi.fn(() => ({
+        doc: vi.fn(() => ({
+          get: vi.fn().mockResolvedValue({
+            exists: true,
+            id: 'booking-1',
+            data: () => rawBookingData,
+          }),
+        })),
+      })),
+    });
+
+    const booking = await getBooking('booking-1');
+
+    expect(booking).not.toBeNull();
+    const trip = booking!.trip!;
+    // This is the actual regression: before the fix, `trip.pickupDateTime` stayed a raw
+    // Timestamp object, and `new Date(timestampObject)` produces an Invalid Date.
+    expect(trip.pickupDateTime).toBeInstanceOf(Date);
+    expect((trip.pickupDateTime as unknown as Date).toISOString()).toBe(pickupIso);
+    expect(new Date(trip.pickupDateTime as unknown as string).getTime()).not.toBeNaN();
+  });
+
+  it('normalizes trip.pickupDateTime across a list of bookings via getBookings', async () => {
+    const pickupIso = '2026-08-02T09:30:00.000Z';
+    const rawBookingData = {
+      status: 'confirmed',
+      trip: {
+        pickup: { address: '456 Elm St' },
+        dropoff: { address: 'LGA' },
+        pickupDateTime: fakeFirestoreTimestamp(pickupIso),
+      },
+      customer: { name: 'John Smith', email: 'john@example.com' },
+      createdAt: fakeFirestoreTimestamp('2026-07-01T10:00:00.000Z'),
+      updatedAt: fakeFirestoreTimestamp('2026-07-01T10:00:00.000Z'),
+    };
+
+    getAdminDb.mockReturnValue({
+      collection: vi.fn(() => ({
+        orderBy: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        get: vi.fn().mockResolvedValue({
+          docs: [{ id: 'booking-2', data: () => rawBookingData }],
+        }),
+      })),
+    });
+
+    const bookings = await getBookings();
+
+    expect(bookings).toHaveLength(1);
+    const trip = bookings[0].trip!;
+    expect(trip.pickupDateTime).toBeInstanceOf(Date);
+    expect((trip.pickupDateTime as unknown as Date).toISOString()).toBe(pickupIso);
+  });
+
+  it('falls back to the flat pickupDateTime field when trip is absent (legacy bookings)', async () => {
+    const pickupIso = '2026-08-03T18:00:00.000Z';
+    const rawBookingData = {
+      status: 'pending',
+      pickupDateTime: fakeFirestoreTimestamp(pickupIso),
+      name: 'Legacy Booking',
+      createdAt: fakeFirestoreTimestamp('2026-07-01T10:00:00.000Z'),
+      updatedAt: fakeFirestoreTimestamp('2026-07-01T10:00:00.000Z'),
+    };
+
+    getAdminDb.mockReturnValue({
+      collection: vi.fn(() => ({
+        doc: vi.fn(() => ({
+          get: vi.fn().mockResolvedValue({
+            exists: true,
+            id: 'booking-legacy',
+            data: () => rawBookingData,
+          }),
+        })),
+      })),
+    });
+
+    const booking = await getBooking('booking-legacy');
+
+    expect(booking).not.toBeNull();
+    expect(booking!.pickupDateTime).toBeInstanceOf(Date);
+    expect((booking!.pickupDateTime as unknown as Date).toISOString()).toBe(pickupIso);
+  });
+});


### PR DESCRIPTION
## Summary

**Critical, live in production, hits every cancellation.** Found via an AI-review sweep this session, verified by hand.

`getBooking()`/`getBookings()` in `booking-service.ts` spread the raw Firestore document (`...data`) and only normalized the flat top-level `pickupDateTime` field — `trip.pickupDateTime` rode through as a raw, un-normalized Firestore Timestamp object. `new Date(Timestamp)` produces an **Invalid Date**, silently — no throw, no log.

### Concrete impact

- **`cancel-booking/route.ts`**: `hoursUntilPickup` became `NaN`. Every `hours >= N` fee-tier check evaluates `false` against `NaN`, so cancellations always fell through to the **highest** fee tier — a customer cancelling a week ahead was charged the same fee as someone cancelling 5 minutes before pickup. No error anywhere; this has been silently overcharging customers on every cancellation.
- **`booking/[bookingId]` PUT route**: the reschedule-detection comparison was always `true` (comparing against `NaN`), so *any* edit to a booking re-triggered the 24h-advance-notice check and re-booked the driver's time slot, even for edits that didn't touch the pickup time at all.
- **`get-bookings-simple/route.ts`**: same bug independently (doesn't go through `getBooking()`), plus the flat `pickupDateTime` it reads is absent on every booking created through the normal submit flow, so it was always `null` there too — masked only because callers happen to prefer `trip.pickupDateTime` first.

## Fix

Normalized at the source: `getBooking()`/`getBookings()` now override `trip.pickupDateTime` with the already-normalized Date before returning, so every caller — existing and future — gets a consistent value whether they read the nested or flat field. Applied the identical fix to `get-bookings-simple`'s independent raw-data path.

Also fixed a related latent issue while in the area: `DriverSchedule.createdAt`/`updatedAt` are typed as `Date` but were never actually converted from Firestore Timestamps at the read boundary — nothing reads them as dates today, but it's the exact same trap waiting for the next feature. Normalized in `driver-scheduling-service.ts`.

## Test plan
- [x] New test `tests/unit/booking-service-timestamp-normalization.test.ts` feeds `getBooking()`/`getBookings()` a Timestamp-shaped `trip.pickupDateTime` (mimics real Firestore: has `.toDate()`, is not a `Date` instance) and asserts the returned value is a real `Date` matching the source time. **This test fails against the pre-fix code.**
- [x] `npm run type-check` — clean
- [x] `npm run lint` on touched files — 0 errors
- [x] Full unit + integration suite — 346 passed, 5 skipped, 0 failed
- [x] `npm run build` — succeeds
- [ ] Manual: verify a real cancellation >24h out now correctly shows a 100% refund in a preview/staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)