### PR TITLE
Fix: Booking type fragmentation causing silent data loss (admin dashboard, admin table)

### DIFF
--- a/src/app/(admin)/admin/AdminDashboardClient.tsx
+++ b/src/app/(admin)/admin/AdminDashboardClient.tsx
@@ -80,7 +80,9 @@ export default function AdminDashboardClient() {
 
         const futureDates: Date[] = [];
         for (const booking of bookings) {
-          const pickupDate = new Date(booking.pickupDateTime);
+          const rawPickupDateTime = booking.trip?.pickupDateTime ?? booking.pickupDateTime;
+          if (!rawPickupDateTime) continue;
+          const pickupDate = new Date(rawPickupDateTime);
           if (Number.isNaN(pickupDate.getTime())) continue;
           if (isSameLocalDay(pickupDate, now)) todaysRides += 1;
           if (pickupDate >= now && booking.status !== 'cancelled') futureDates.push(pickupDate);

--- a/src/app/(admin)/admin/bookings/BookingsTable.tsx
+++ b/src/app/(admin)/admin/bookings/BookingsTable.tsx
@@ -40,6 +40,7 @@ import {
   getCustomerPhone,
   getDepositPaid,
   getDropoffAddress,
+  getFlightNumber,
   getPickupAddress,
   getPickupDateTime,
   getStatusIcon,
@@ -133,9 +134,9 @@ export function BookingsTable({
                 <DetailSection>
                   <DetailLabel>Pickup Date & Time</DetailLabel>
                   <DetailValue>{formatDate(getPickupDateTime(booking))}</DetailValue>
-                  {booking.flightNumber && (
+                  {getFlightNumber(booking) && (
                     <Text variant="small" color="secondary" style={{ marginTop: '4px' }}>
-                      ✈️ Flight: {booking.flightNumber}
+                      ✈️ Flight: {getFlightNumber(booking)}
                     </Text>
                   )}
                 </DetailSection>

--- a/src/app/(admin)/admin/bookings/bookings-utils.ts
+++ b/src/app/(admin)/admin/bookings/bookings-utils.ts
@@ -34,22 +34,25 @@ export const formatCurrency = (amount: number): string =>
   }).format(amount);
 
 export const getBookingFare = (booking: Booking): number =>
-  (booking as any).trip?.fare ?? booking.fare ?? 0;
+  booking.trip?.fare ?? booking.fare ?? 0;
 
 export const getCustomerName = (booking: Booking): string =>
-  (booking as any).customer?.name ?? booking.name ?? 'Unknown';
+  booking.customer?.name ?? booking.name ?? 'Unknown';
 
 export const getCustomerEmail = (booking: Booking): string =>
-  (booking as any).customer?.email ?? booking.email ?? '';
+  booking.customer?.email ?? booking.email ?? '';
 
 export const getCustomerPhone = (booking: Booking): string =>
-  (booking as any).customer?.phone ?? booking.phone ?? '';
+  booking.customer?.phone ?? booking.phone ?? '';
 
 export const getPickupAddress = (booking: Booking): string =>
-  (booking as any).trip?.pickup?.address ?? booking.pickupLocation ?? '';
+  booking.trip?.pickup?.address ?? booking.pickupLocation ?? '';
 
 export const getDropoffAddress = (booking: Booking): string =>
-  (booking as any).trip?.dropoff?.address ?? booking.dropoffLocation ?? '';
+  booking.trip?.dropoff?.address ?? booking.dropoffLocation ?? '';
+
+export const getFlightNumber = (booking: Booking): string =>
+  booking.trip?.flightInfo?.flightNumber ?? booking.flightNumber ?? '';
 
 export const getAirportFromBooking = (booking: Booking): string | null => {
   const pickup = getPickupAddress(booking).toLowerCase();
@@ -74,18 +77,18 @@ export const getAirportFromBooking = (booking: Booking): string | null => {
 };
 
 export const getConfirmationSent = (booking: Booking): boolean => {
-  const sentAt = (booking as any).confirmation?.sentAt ?? (booking as any).confirmationSentAt;
+  const sentAt = booking.confirmation?.sentAt ?? (booking as { confirmationSentAt?: unknown }).confirmationSentAt;
   return Boolean(sentAt);
 };
 
-export const getPickupDateTime = (booking: Booking): any =>
-  (booking as any).trip?.pickupDateTime ?? booking.pickupDateTime;
+export const getPickupDateTime = (booking: Booking): Date | string | undefined =>
+  booking.trip?.pickupDateTime ?? booking.pickupDateTime;
 
 export const getBalanceDue = (booking: Booking): number =>
-  (booking as any).payment?.balanceDue ?? booking.balanceDue ?? 0;
+  booking.payment?.balanceDue ?? booking.balanceDue ?? 0;
 
 export const getDepositPaid = (booking: Booking): boolean =>
-  (booking as any).payment?.depositPaid ?? booking.depositPaid ?? false;
+  booking.payment?.depositPaid ?? booking.depositPaid ?? false;
 
 export const getStatusIcon = (status: string): string => {
   switch (status) {

--- a/src/lib/services/database-service.ts
+++ b/src/lib/services/database-service.ts
@@ -35,19 +35,25 @@ const safeToDate = (dateField: any): Date => {
 };
 
 // ===== BOOKINGS =====
+// Legacy flat fields below are optional, not required — a booking created through the normal
+// submit flow only ever populates the nested `trip`/`customer`/`payment` shape (see
+// booking-orchestrator.ts); the flat fields exist purely for pre-migration records. Declaring
+// them as required was inaccurate and forced every real consumer to `as any`-cast just to reach
+// `trip`/`customer`/`payment`, which weren't declared here at all despite being present on every
+// real Firestore document. Both gaps are fixed below.
 export interface Booking {
   id?: string;
-  name: string;
-  email: string;
-  phone: string;
-  pickupLocation: string;
-  dropoffLocation: string;
-  pickupDateTime: Date;
+  name?: string;
+  email?: string;
+  phone?: string;
+  pickupLocation?: string;
+  dropoffLocation?: string;
+  pickupDateTime?: Date;
   status: 'pending' | 'confirmed' | 'in-progress' | 'completed' | 'cancelled' | 'requires_approval';
-  fare: number;
+  fare?: number;
   dynamicFare?: number;
-  depositPaid: boolean;
-  balanceDue: number;
+  depositPaid?: boolean;
+  balanceDue?: number;
   flightNumber?: string;
   notes?: string;
   driverId?: string;
@@ -76,25 +82,76 @@ export interface Booking {
     sentAt?: string;
     confirmedAt?: string;
   };
+  calendarEventId?: string;
   createdAt: Date;
   updatedAt: Date;
+
+  // Nested structure (modern format) — present on every booking created through the normal flow.
+  trip?: {
+    pickup: { address: string; coordinates?: { lat: number; lng: number } | null };
+    dropoff: { address: string; coordinates?: { lat: number; lng: number } | null };
+    pickupDateTime: Date | string;
+    fare?: number;
+    fareType?: 'personal' | 'business';
+    flightInfo?: {
+      hasFlight: boolean;
+      airline: string;
+      flightNumber: string;
+      arrivalTime: string;
+      terminal: string;
+    };
+  };
+  customer?: {
+    name: string;
+    email: string;
+    phone: string;
+    notes?: string;
+    saveInfoForFuture?: boolean;
+    smsOptIn?: boolean;
+  };
+  payment?: {
+    depositAmount: number | null;
+    balanceDue: number;
+    depositPaid: boolean;
+    squareOrderId?: string;
+    squarePaymentId?: string;
+    tipAmount: number;
+    tipPercent: number;
+    totalAmount: number;
+  };
+  driverLocation?: {
+    lat: number;
+    lng: number;
+    timestamp: Date;
+    heading?: number;
+    speed?: number;
+  };
 }
+
+// `...data` below carries the raw (un-normalized) Firestore Timestamp through on
+// `data.trip.pickupDateTime` — this mirrors and must stay in sync with the same fix in
+// src/lib/services/booking-service.ts's getBooking()/getBookings(). Without it,
+// `new Date(booking.trip.pickupDateTime)` on a raw Timestamp silently produces an Invalid Date.
+const normalizeBookingDoc = (id: string, data: any): Booking => {
+  const pickupDateTimeRaw = data?.trip?.pickupDateTime ?? data?.pickupDateTime;
+  const normalizedPickupDateTime = safeToDate(pickupDateTimeRaw);
+
+  return {
+    id,
+    ...data,
+    ...(data?.trip ? { trip: { ...data.trip, pickupDateTime: normalizedPickupDateTime } } : {}),
+    pickupDateTime: normalizedPickupDateTime,
+    estimatedArrival: data.estimatedArrival ? safeToDate(data.estimatedArrival) : undefined,
+    actualArrival: data.actualArrival ? safeToDate(data.actualArrival) : undefined,
+    createdAt: safeToDate(data.createdAt),
+    updatedAt: safeToDate(data.updatedAt),
+  } as Booking;
+};
 
 export const getAllBookings = async (): Promise<Booking[]> => {
   try {
     const snapshot = await getDocs(collection(db, 'bookings'));
-    return snapshot.docs.map(doc => {
-      const data = doc.data();
-      return {
-        id: doc.id,
-        ...data,
-        pickupDateTime: safeToDate(data.pickupDateTime),
-        estimatedArrival: data.estimatedArrival ? safeToDate(data.estimatedArrival) : undefined,
-        actualArrival: data.actualArrival ? safeToDate(data.actualArrival) : undefined,
-        createdAt: safeToDate(data.createdAt),
-        updatedAt: safeToDate(data.updatedAt),
-      } as Booking;
-    });
+    return snapshot.docs.map(doc => normalizeBookingDoc(doc.id, doc.data()));
   } catch (error) {
     console.error('Error fetching bookings:', error);
     return [];
@@ -109,18 +166,7 @@ export const getBookingsByStatus = async (status: Booking['status']): Promise<Bo
       orderBy('createdAt', 'desc')
     );
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => {
-      const data = doc.data();
-      return {
-        id: doc.id,
-        ...data,
-        pickupDateTime: safeToDate(data.pickupDateTime),
-        estimatedArrival: data.estimatedArrival ? safeToDate(data.estimatedArrival) : undefined,
-        actualArrival: data.actualArrival ? safeToDate(data.actualArrival) : undefined,
-        createdAt: safeToDate(data.createdAt),
-        updatedAt: safeToDate(data.updatedAt),
-      } as Booking;
-    });
+    return snapshot.docs.map(doc => normalizeBookingDoc(doc.id, doc.data()));
   } catch (error) {
     console.error('Error fetching bookings by status:', error);
     throw new Error('Failed to fetch bookings');
@@ -308,7 +354,7 @@ export const getBookingStats = async () => {
     const cancelledBookings = bookings.filter(b => b.status === 'cancelled').length;
     const totalRevenue = bookings
       .filter(b => b.status === 'completed')
-      .reduce((sum, b) => sum + b.fare, 0);
+      .reduce((sum, b) => sum + (b.trip?.fare ?? b.fare ?? 0), 0);
     
     return {
       totalBookings,
@@ -432,17 +478,17 @@ export const getMarketingCustomers = async (): Promise<MarketingCustomer[]> => {
         existing.bookings.push(booking);
         // Use most recent name/email/smsOptIn (latest booking takes precedence)
         if (booking.createdAt > existing.bookings[0].createdAt) {
-          existing.name = booking.name;
-          existing.email = booking.email;
+          existing.name = booking.name ?? existing.name;
+          existing.email = booking.email ?? existing.email;
           // If they opted in on any booking, consider them opted in
           // If they opted out on a later booking, respect that
           existing.smsOptIn = booking.smsOptIn ?? existing.smsOptIn;
         }
       } else {
         customerMap.set(normalizedPhone, {
-          name: booking.name,
+          name: booking.name ?? 'Unknown',
           phone: booking.phone,
-          email: booking.email,
+          email: booking.email ?? '',
           smsOptIn: booking.smsOptIn ?? false,
           bookings: [booking],
         });
@@ -463,12 +509,12 @@ export const getMarketingCustomers = async (): Promise<MarketingCustomer[]> => {
       );
 
       const lastBooking = data.bookings.reduce((latest, b) =>
-        !latest || b.pickupDateTime > latest.pickupDateTime ? b : latest
+        !latest || (b.pickupDateTime && latest.pickupDateTime && b.pickupDateTime > latest.pickupDateTime) ? b : latest
       , null as Booking | null);
 
-      const totalSpent = completedBookings.reduce((sum, b) => sum + b.fare, 0);
+      const totalSpent = completedBookings.reduce((sum, b) => sum + (b.trip?.fare ?? b.fare ?? 0), 0);
 
-      const isActive = lastBooking
+      const isActive = lastBooking?.pickupDateTime
         ? lastBooking.pickupDateTime >= ninetyDaysAgo
         : false;
 

--- a/tests/unit/bookings-utils.test.ts
+++ b/tests/unit/bookings-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getFlightNumber,
+  getPickupAddress,
+  getDropoffAddress,
+  getCustomerName,
+  getBookingFare,
+} from '@/app/(admin)/admin/bookings/bookings-utils';
+import type { Booking } from '@/lib/services/database-service';
+
+describe('bookings-utils accessors', () => {
+  it('getFlightNumber reads the nested trip.flightInfo.flightNumber for modern bookings (regression: admin table used to read only the flat field, which is never populated at booking creation)', () => {
+    const booking = {
+      status: 'confirmed',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      trip: {
+        pickup: { address: '123 Main St' },
+        dropoff: { address: 'JFK' },
+        pickupDateTime: new Date(),
+        flightInfo: { hasFlight: true, airline: 'Delta', flightNumber: 'DL123', arrivalTime: '', terminal: '4' },
+      },
+      // Flat legacy field intentionally absent, matching a real booking created through the
+      // normal submit flow (createBookingAtomic never populates it at creation time).
+    } as unknown as Booking;
+
+    expect(getFlightNumber(booking)).toBe('DL123');
+  });
+
+  it('getFlightNumber falls back to the legacy flat field for pre-migration bookings', () => {
+    const booking = {
+      status: 'confirmed',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      flightNumber: 'AA456',
+    } as unknown as Booking;
+
+    expect(getFlightNumber(booking)).toBe('AA456');
+  });
+
+  it('getFlightNumber returns empty string when neither shape has flight info', () => {
+    const booking = {
+      status: 'pending',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as Booking;
+
+    expect(getFlightNumber(booking)).toBe('');
+  });
+
+  it('other accessors continue to prefer the nested shape (existing behavior, unaffected by the type change)', () => {
+    const booking = {
+      status: 'confirmed',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      trip: {
+        pickup: { address: '123 Main St' },
+        dropoff: { address: 'JFK' },
+        pickupDateTime: new Date(),
+        fare: 150,
+      },
+      customer: { name: 'Jane Doe', email: 'jane@example.com', phone: '+12035550123' },
+    } as unknown as Booking;
+
+    expect(getPickupAddress(booking)).toBe('123 Main St');
+    expect(getDropoffAddress(booking)).toBe('JFK');
+    expect(getCustomerName(booking)).toBe('Jane Doe');
+    expect(getBookingFare(booking)).toBe(150);
+  });
+});

--- a/tests/unit/database-service-timestamp-normalization.test.ts
+++ b/tests/unit/database-service-timestamp-normalization.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getDocs = vi.fn();
+const collection = vi.fn(() => 'bookings-collection-ref');
+const query = vi.fn((...args) => args);
+const where = vi.fn(() => 'where-clause');
+const orderBy = vi.fn(() => 'orderby-clause');
+
+vi.mock('firebase/firestore', () => ({
+  collection,
+  getDocs,
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query,
+  where,
+  orderBy,
+  serverTimestamp: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/firebase-server', () => ({
+  db: {},
+}));
+
+// Mimics a real Firestore Timestamp: has a .toDate() method, is NOT a Date instance.
+function fakeFirestoreTimestamp(iso: string) {
+  const date = new Date(iso);
+  return { _seconds: Math.floor(date.getTime() / 1000), _nanoseconds: 0, toDate: () => date };
+}
+
+describe('database-service.ts — Timestamp normalization (admin bookings page read path)', () => {
+  let getAllBookings: typeof import('@/lib/services/database-service').getAllBookings;
+  let getBookingsByStatus: typeof import('@/lib/services/database-service').getBookingsByStatus;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    ({ getAllBookings, getBookingsByStatus } = await import('@/lib/services/database-service'));
+  });
+
+  it('getAllBookings normalizes a raw Firestore Timestamp on trip.pickupDateTime (regression: this is a separate read path from booking-service.ts and had the identical bug)', async () => {
+    const pickupIso = '2026-08-05T12:00:00.000Z';
+    getDocs.mockResolvedValue({
+      docs: [
+        {
+          id: 'booking-1',
+          data: () => ({
+            status: 'confirmed',
+            trip: {
+              pickup: { address: '123 Main St' },
+              dropoff: { address: 'JFK' },
+              pickupDateTime: fakeFirestoreTimestamp(pickupIso),
+            },
+            createdAt: fakeFirestoreTimestamp('2026-07-01T00:00:00.000Z'),
+            updatedAt: fakeFirestoreTimestamp('2026-07-01T00:00:00.000Z'),
+          }),
+        },
+      ],
+    });
+
+    const bookings = await getAllBookings();
+
+    expect(bookings).toHaveLength(1);
+    expect(bookings[0].trip?.pickupDateTime).toBeInstanceOf(Date);
+    expect((bookings[0].trip?.pickupDateTime as Date).toISOString()).toBe(pickupIso);
+    expect(new Date(bookings[0].trip!.pickupDateTime as string).getTime()).not.toBeNaN();
+  });
+
+  it('getBookingsByStatus normalizes trip.pickupDateTime the same way', async () => {
+    const pickupIso = '2026-08-06T08:30:00.000Z';
+    getDocs.mockResolvedValue({
+      docs: [
+        {
+          id: 'booking-2',
+          data: () => ({
+            status: 'pending',
+            trip: {
+              pickup: { address: '456 Elm St' },
+              dropoff: { address: 'LGA' },
+              pickupDateTime: fakeFirestoreTimestamp(pickupIso),
+            },
+            createdAt: fakeFirestoreTimestamp('2026-07-01T00:00:00.000Z'),
+            updatedAt: fakeFirestoreTimestamp('2026-07-01T00:00:00.000Z'),
+          }),
+        },
+      ],
+    });
+
+    const bookings = await getBookingsByStatus('pending');
+
+    expect(bookings).toHaveLength(1);
+    expect(bookings[0].trip?.pickupDateTime).toBeInstanceOf(Date);
+    expect((bookings[0].trip?.pickupDateTime as Date).toISOString()).toBe(pickupIso);
+  });
+});

--- a/tests/unit/database-service-timestamp-normalization.test.ts
+++ b/tests/unit/database-service-timestamp-normalization.test.ts
@@ -8,6 +8,7 @@ const orderBy = vi.fn(() => 'orderby-clause');
 
 vi.mock('firebase/firestore', () => ({
   collection,
+  doc: vi.fn(() => ({})),
   getDocs,
   addDoc: vi.fn(),
   updateDoc: vi.fn(),


### PR DESCRIPTION
## Scope decision (stated up front)

This consolidates the two type sources that were actually causing bugs — not a full merge of all 4 divergent \`Booking\` type definitions found in this session's audit. \`types/booking.ts\` (customer form-state, string dates) and \`booking-service.ts\`'s \`Booking\` (server-persisted state, Date objects) serve genuinely different layers; merging them fully would touch 40+ files for marginal benefit over what's fixed here. Flagging this as a deliberate non-goal rather than silently under-delivering on "full consolidation."

## What's fixed

**1. \`database-service.ts\`'s \`Booking\` type didn't declare \`trip\`/\`customer\`/\`payment\` at all**, despite every real Firestore document having them — only the legacy flat mirror was typed. Every consumer had to \`(booking as any).trip?...\` just to reach nested data, which defeated type-checking entirely. Added the missing nested fields, and corrected several flat fields that were declared *required* but are actually always \`undefined\` on modern bookings (a booking created via the normal submit flow never populates the legacy mirror at creation time).

**2. That type-correctness fix immediately surfaced three real, previously-invisible-to-the-compiler bugs** — TypeScript could finally see these fields as optional instead of trusting a lie:

- **Admin dashboard's "today's rides" / "next ride" widget** read only the flat \`pickupDateTime\` field, which is \`undefined\` on every modern booking → every current booking was silently excluded from that count. Live, user-facing, fixed.
- **Admin bookings table** read \`booking.flightNumber\` directly (flat only, no fallback) — unlike every other field on that page, which already goes through a nested-first accessor. Flight numbers entered at booking creation were invisible in the admin UI, only showing up if the customer later used the (separately fixed) post-submit edit flow. Added \`getFlightNumber()\` to \`bookings-utils.ts\`, matching the existing accessor pattern.
- **\`database-service.ts\`'s \`getAllBookings()\`/\`getBookingsByStatus()\`** — the actual read path the admin bookings page uses, a *separate* code path from the Admin-SDK route fixed in the earlier Timestamp-normalization PR (#38) — had the identical raw-Timestamp bug. Fixed the same way.

**3. \`getBookingStats\`/\`getMarketingCustomers\`** (confirmed unused anywhere in the app via grep) had the same flat-field-only bugs; fixed to compile correctly and use the same nested-first pattern, since they're exported and may get wired up later.

## Test plan
- [x] New \`tests/unit/bookings-utils.test.ts\` — proves \`getFlightNumber\` reads the nested shape correctly (and falls back for legacy records)
- [x] New \`tests/unit/database-service-timestamp-normalization.test.ts\` — proves this independent read path normalizes Timestamps correctly (mirrors the proof pattern from #38)
- [x] \`npm run type-check\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] Full unit + integration suite — 349 passed, 5 skipped, 0 failed
- [x] \`npm run build\` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)