### PR TITLE
Fix: SMOKE_TEST_MODE didn't actually suppress email/SMS on booking create or cancel

### DIFF
--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -58,11 +58,30 @@ E2E_BASE_URL="https://www.fairfieldairportcar.com" npm run test:e2e:preview-safe
 Run with emulators:
 ```bash
 NEXT_PUBLIC_USE_EMULATORS=true npm run firebase:emulators
-NEXT_PUBLIC_USE_EMULATORS=true npm run test:e2e:full-flow
+NEXT_PUBLIC_USE_EMULATORS=true SMOKE_TEST_MODE=true npm run test:e2e:full-flow
 ```
+
+**Always set `SMOKE_TEST_MODE=true` for any local run that submits, pays for, or cancels a
+booking** — including ad hoc manual testing (curl, a local dev server, a one-off script), not
+just the `full-flow` suite. `NEXT_PUBLIC_USE_EMULATORS=true` only sandboxes Firestore/Auth; it
+does **not** sandbox email or SMS. Without `SMOKE_TEST_MODE=true`, a "local" test booking will
+still send a real verification email, real driver notification, and real admin SMS/email through
+whatever `EMAIL_*`/`TWILIO_*` credentials are in your `.env` — this happened for real on
+2026-07-16 (a local validation test emailed a real inbox and would have texted the admin, using
+production-shaped notification content, for a booking that only ever existed in the local
+emulator). `SMOKE_TEST_MODE=true` makes booking creation, cancellation, and calendar/payment code
+paths skip all of those real external sends and log what would have happened instead.
+
+**Also seed or expect defaults for `config/pricing`.** An unseeded local Firestore (a fresh
+emulator, or a database missing that doc) falls back to `DEFAULT_PRICING_CONFIG` in
+`pricing-config.ts` — generic rates, not whatever the business has actually configured in
+production. `getPricingConfig()` now logs a loud warning when this happens, but don't be
+surprised by a quote that doesn't match a real customer's rate for the "same" route; it isn't
+using the same pricing config.
 
 ## Rule of thumb
 
 - Use `ui-mocked` to catch UI breakages.
 - Use `preview-safe` to confirm deployed behavior safely.
-- Use `full-flow` only where writes are acceptable (emulator/staging).
+- Use `full-flow` only where writes are acceptable (emulator/staging), and always with
+  `SMOKE_TEST_MODE=true`.

--- a/src/app/api/booking/cancel-booking/route.ts
+++ b/src/app/api/booking/cancel-booking/route.ts
@@ -69,28 +69,35 @@ export async function POST(req: NextRequest) {
     const messageBody = `Your ride has been cancelled.\nPickup time: ${pickupTimeLabel}\n${
       refundAmount === 0 ? (cancellationFee > 0 ? `A cancellation fee of $${cancellationFee.toFixed(2)} applies.` : 'No refund applies.') : `We have refunded $${refundAmount.toFixed(2)}.`}`;
 
-    // Send SMS and email (push removed)
-    await Promise.all([
-      phone ? sendSms({ to: phone, body: messageBody }) : Promise.resolve(),
-      email ? sendConfirmationEmail(adaptOldBookingToNew({ ...booking, status: 'cancelled', updatedAt: new Date(), cancellationFee })) : Promise.resolve(),
-    ]);
+    // Smoke test mode is a server-only env flag — never derived from a client-supplied header.
+    const isSmokeTest = process.env.SMOKE_TEST_MODE === 'true';
 
-    try {
-      const { sendAdminSms } = await import('@/lib/services/admin-notification-service');
-      const customerName = booking.customer?.name || booking.name || 'Customer';
-      const pickupDateTimeStr = pickupDateTime ? formatBusinessDateTimeWithZone(pickupDateTime) : 'scheduled time';
-      const message = `Booking cancelled: ${bookingId} - ${customerName} - Pickup time: ${pickupDateTimeStr} - Refund: $${refundAmount.toFixed(2)}`;
-      await sendAdminSms(message);
-      console.log('✅ [CANCEL BOOKING] Admin SMS sent successfully');
-    } catch (smsError) {
-      console.error('❌ [CANCEL BOOKING] Failed to send admin SMS:', smsError);
+    if (isSmokeTest) {
+      console.log(`🧪 Smoke test mode - skipping customer SMS/email and admin SMS for cancelled booking ${bookingId}`);
+    } else {
+      // Send SMS and email (push removed)
+      await Promise.all([
+        phone ? sendSms({ to: phone, body: messageBody }) : Promise.resolve(),
+        email ? sendConfirmationEmail(adaptOldBookingToNew({ ...booking, status: 'cancelled', updatedAt: new Date(), cancellationFee })) : Promise.resolve(),
+      ]);
+
+      try {
+        const { sendAdminSms } = await import('@/lib/services/admin-notification-service');
+        const customerName = booking.customer?.name || booking.name || 'Customer';
+        const pickupDateTimeStr = pickupDateTime ? formatBusinessDateTimeWithZone(pickupDateTime) : 'scheduled time';
+        const message = `Booking cancelled: ${bookingId} - ${customerName} - Pickup time: ${pickupDateTimeStr} - Refund: $${refundAmount.toFixed(2)}`;
+        await sendAdminSms(message);
+        console.log('✅ [CANCEL BOOKING] Admin SMS sent successfully');
+      } catch (smsError) {
+        console.error('❌ [CANCEL BOOKING] Failed to send admin SMS:', smsError);
+      }
     }
 
     return NextResponse.json({
       message: 'Booking cancelled',
       refundAmount,
       cancellationFee,
-      channels: ['sms', 'email'],
+      channels: isSmokeTest ? [] : ['sms', 'email'],
     });
   } catch (err) {
     console.error('Cancel booking error', err);

--- a/src/lib/business/pricing-config.ts
+++ b/src/lib/business/pricing-config.ts
@@ -44,6 +44,16 @@ export async function getPricingConfig(): Promise<PricingConfig> {
     const docRef = db.collection('config').doc('pricing');
     const snap = await docRef.get();
     if (!snap.exists) {
+      // Loud on purpose: silently falling back to generic defaults produced a real quote that
+      // looked wrong (2026-07-16) — a local emulator with no seeded config/pricing doc quoted
+      // ~$126 for a route the real configured rates would have priced closer to $160. Anyone
+      // pointed at an empty/unseeded Firestore (emulator, fresh env) needs to see this
+      // immediately, not discover it after a confusing quote reaches someone.
+      console.warn(
+        '⚠️  config/pricing document not found in Firestore — using DEFAULT_PRICING_CONFIG ' +
+        `(baseFare=$${DEFAULT_PRICING_CONFIG.baseFare}, perMile=$${DEFAULT_PRICING_CONFIG.perMile}, perMinute=$${DEFAULT_PRICING_CONFIG.perMinute}), ` +
+        'NOT the real configured business rates. Quotes generated right now will not match production pricing.'
+      );
       cached = { config: DEFAULT_PRICING_CONFIG, at: Date.now() };
       return DEFAULT_PRICING_CONFIG;
     }

--- a/src/lib/services/booking-orchestrator.ts
+++ b/src/lib/services/booking-orchestrator.ts
@@ -312,56 +312,66 @@ export async function submitBookingOrchestration(
       throw new Error('Booking was created but could not be retrieved');
     }
 
-    await createTentativeCalendarEventForBooking(bookingResult.bookingId, bookingRecord);
+    // Smoke test mode must suppress every real external side effect, not just calendar/payment —
+    // this is what actually failed 2026-07-16: a local test booking sent a real driver
+    // notification email and (would have) texted the admin, because nothing here checked this
+    // flag. Never derive this from a request header — only the server's own env can set it.
+    const isSmokeTest = process.env.SMOKE_TEST_MODE === 'true';
+
+    await createTentativeCalendarEventForBooking(bookingResult.bookingId, bookingRecord, isSmokeTest);
 
     const confirmationUrlBase =
       process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
     const confirmationUrl = `${confirmationUrlBase}/booking/confirm?bookingId=${bookingResult.bookingId}&token=${resolvedConfirmationToken}`;
 
-    try {
-      await sendBookingVerificationEmail(bookingRecord as unknown as Booking, confirmationUrl);
-    } catch {
-      emailWarning =
-        'Your ride request is saved, but we could not send the confirmation email. Please text us at (203) 990-1815 so we can finalize it.';
-      await recordBookingAttempt({
-        stage: 'submit',
-        status: 'warning',
-        bookingId: bookingResult.bookingId,
-        reason: emailWarning,
-        customerName: customer.name,
-        customerEmail: customer.email,
-        customerPhone: customer.phone,
-        pickupAddress: trip.pickup.address,
-        dropoffAddress: trip.dropoff.address,
-        pickupDateTime: trip.pickupDateTime.toISOString(),
-      });
-    }
+    if (isSmokeTest) {
+      console.log(`🧪 Smoke test mode - skipping verification email, driver notifications, and admin SMS for booking ${bookingResult.bookingId}`);
+    } else {
+      try {
+        await sendBookingVerificationEmail(bookingRecord as unknown as Booking, confirmationUrl);
+      } catch {
+        emailWarning =
+          'Your ride request is saved, but we could not send the confirmation email. Please text us at (203) 990-1815 so we can finalize it.';
+        await recordBookingAttempt({
+          stage: 'submit',
+          status: 'warning',
+          bookingId: bookingResult.bookingId,
+          reason: emailWarning,
+          customerName: customer.name,
+          customerEmail: customer.email,
+          customerPhone: customer.phone,
+          pickupAddress: trip.pickup.address,
+          dropoffAddress: trip.dropoff.address,
+          pickupDateTime: trip.pickupDateTime.toISOString(),
+        });
+      }
 
-    try {
-      await sendDriverNotificationEmail(bookingRecord as unknown as Booking);
-    } catch {
-      // Non-critical
-    }
+      try {
+        await sendDriverNotificationEmail(bookingRecord as unknown as Booking);
+      } catch {
+        // Non-critical
+      }
 
-    try {
-      await notifyDriverOfNewBooking({
-        bookingId: bookingResult.bookingId,
-        customerName: customer.name,
-        pickupAddress: trip.pickup.address,
-        dropoffAddress: trip.dropoff.address,
-        pickupDateTime: trip.pickupDateTime.toISOString(),
-        fare,
-      });
-    } catch {
-      // Non-critical
-    }
+      try {
+        await notifyDriverOfNewBooking({
+          bookingId: bookingResult.bookingId,
+          customerName: customer.name,
+          pickupAddress: trip.pickup.address,
+          dropoffAddress: trip.dropoff.address,
+          pickupDateTime: trip.pickupDateTime.toISOString(),
+          fare,
+        });
+      } catch {
+        // Non-critical
+      }
 
-    try {
-      const pickupDateTimeStr = formatBusinessDateTimeWithZone(trip.pickupDateTime);
-      const message = `New booking: ${customer.name} - Pickup time: ${pickupDateTimeStr} - Route: ${trip.pickup.address} -> ${trip.dropoff.address} - $${fare.toFixed(2)}`;
-      await sendAdminSms(message);
-    } catch {
-      // Non-critical
+      try {
+        const pickupDateTimeStr = formatBusinessDateTimeWithZone(trip.pickupDateTime);
+        const message = `New booking: ${customer.name} - Pickup time: ${pickupDateTimeStr} - Route: ${trip.pickup.address} -> ${trip.dropoff.address} - $${fare.toFixed(2)}`;
+        await sendAdminSms(message);
+      } catch {
+        // Non-critical
+      }
     }
 
     return {
@@ -488,13 +498,19 @@ export async function createPaidBookingAndNotify(
       const confirmationUrlBase =
         process.env.NEXT_PUBLIC_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
       const confirmationUrl = `${confirmationUrlBase}/booking/confirm?bookingId=${bookingResult.bookingId}&token=${confirmationToken}`;
-      await sendBookingVerificationEmail(adaptOldBookingToNew(bookingRecord), confirmationUrl);
 
-      const smsMessage = `We received your booking request.\nPickup time: ${formatBusinessDateTimeWithZone(pickupDateTimeValue)}\nPlease check your email to confirm the ride. Booking ID: ${bookingResult.bookingId}`;
-      await sendSms({
-        to: bookingData.customer.phone,
-        body: smsMessage,
-      });
+      const isSmokeTest = smokeTest || process.env.SMOKE_TEST_MODE === 'true';
+      if (isSmokeTest) {
+        console.log(`🧪 Smoke test mode - skipping verification email and SMS for booking ${bookingResult.bookingId}`);
+      } else {
+        await sendBookingVerificationEmail(adaptOldBookingToNew(bookingRecord), confirmationUrl);
+
+        const smsMessage = `We received your booking request.\nPickup time: ${formatBusinessDateTimeWithZone(pickupDateTimeValue)}\nPlease check your email to confirm the ride. Booking ID: ${bookingResult.bookingId}`;
+        await sendSms({
+          to: bookingData.customer.phone,
+          body: smsMessage,
+        });
+      }
     }
   } catch (notificationError) {
     console.error('Failed to send verification notifications:', notificationError);

--- a/tests/integration/booking-server-flow.test.ts
+++ b/tests/integration/booking-server-flow.test.ts
@@ -46,6 +46,8 @@ vi.mock('@/lib/utils/auth-server', () => ({
 import * as quoteService from '@/lib/services/quote-service';
 import * as bookingService from '@/lib/services/booking-service';
 import { sendAdminSms } from '@/lib/services/admin-notification-service';
+import { sendBookingVerificationEmail, sendDriverNotificationEmail } from '@/lib/services/email-service';
+import { notifyDriverOfNewBooking } from '@/lib/services/driver-notification-service';
 
 let validatePhasePOST: typeof import('@/app/api/booking/validate-phase/route').POST;
 let submitPOST: typeof import('@/app/api/booking/submit/route').POST;
@@ -229,5 +231,46 @@ describe('Booking server golden path', () => {
     expect(submitRes.status).toBe(200);
     expect(submitData.success).toBe(true);
     expect(sendAdminSms).toHaveBeenCalledWith(expect.stringContaining('3/2/2026, 8:00 AM'));
+  });
+
+  it('SMOKE_TEST_MODE=true suppresses the verification email, driver notifications, and admin SMS (regression: a real local test booking on 2026-07-16 sent a real notification because nothing checked this flag)', async () => {
+    const previousSmokeTestMode = process.env.SMOKE_TEST_MODE;
+    process.env.SMOKE_TEST_MODE = 'true';
+
+    try {
+      vi.mocked(quoteService.getQuote).mockResolvedValue({
+        pickupAddress: submitPayload.trip.pickup.address,
+        dropoffAddress: submitPayload.trip.dropoff.address,
+        pickupDateTime: submitPayload.trip.pickupDateTime,
+        fareType: submitPayload.trip.fareType,
+        price: submitPayload.fare,
+      } as any);
+
+      vi.mocked(bookingService.createBookingAtomic).mockResolvedValue({ bookingId: 'booking_smoke' });
+      vi.mocked(bookingService.getBooking).mockResolvedValue({
+        id: 'booking_smoke',
+        confirmation: { token: 'tok_smoke' },
+        customer: { email: submitPayload.customer.email },
+        trip: {
+          pickup: { address: submitPayload.trip.pickup.address },
+          dropoff: { address: submitPayload.trip.dropoff.address },
+          pickupDateTime: submitPayload.trip.pickupDateTime,
+        },
+        payment: { totalAmount: submitPayload.fare },
+        status: 'pending',
+      } as any);
+
+      const submitRes = await submitPOST(req('http://localhost/api/booking/submit', submitPayload));
+      const submitData = await submitRes.json();
+
+      expect(submitRes.status).toBe(200);
+      expect(submitData.success).toBe(true);
+      expect(sendBookingVerificationEmail).not.toHaveBeenCalled();
+      expect(sendDriverNotificationEmail).not.toHaveBeenCalled();
+      expect(notifyDriverOfNewBooking).not.toHaveBeenCalled();
+      expect(sendAdminSms).not.toHaveBeenCalled();
+    } finally {
+      process.env.SMOKE_TEST_MODE = previousSmokeTestMode;
+    }
   });
 });

--- a/tests/unit/cancel-booking.route.test.ts
+++ b/tests/unit/cancel-booking.route.test.ts
@@ -226,6 +226,29 @@ describe('POST /api/booking/cancel-booking', () => {
     });
   });
 
+  it('SMOKE_TEST_MODE=true suppresses customer SMS/email and admin SMS (regression: see booking-server-flow.test.ts for the same fix on booking creation)', async () => {
+    const previousSmokeTestMode = process.env.SMOKE_TEST_MODE;
+    process.env.SMOKE_TEST_MODE = 'true';
+
+    try {
+      const booking = createMockBooking(48, 75);
+      mockGetBooking.mockResolvedValueOnce(booking);
+      mockCancelBooking.mockResolvedValueOnce(undefined);
+
+      const response = await POST(buildRequest({ bookingId: 'booking-123' }));
+      const payload = await response!.json();
+
+      expect(response!.status).toBe(200);
+      expect(mockCancelBooking).toHaveBeenCalled();
+      expect(mockSendSms).not.toHaveBeenCalled();
+      expect(mockSendConfirmationEmail).not.toHaveBeenCalled();
+      expect(mockSendAdminSms).not.toHaveBeenCalled();
+      expect(payload.channels).toEqual([]);
+    } finally {
+      process.env.SMOKE_TEST_MODE = previousSmokeTestMode;
+    }
+  });
+
   it('passes options without squarePaymentId when no payment ID is available', async () => {
     const booking = createMockBooking(48, 75);
     (booking.payment as Record<string, unknown>).squarePaymentId = undefined; // No payment ID


### PR DESCRIPTION
## What happened

Real incident earlier today: a local validation test (dev server pointed at the Firestore emulator, testing an unrelated flight-info fix) sent a real driver-notification email and would have texted the admin — for a booking that only ever existed in the local emulator.

## Root cause

`SMOKE_TEST_MODE` already existed in this codebase and correctly gates calendar event creation and payment mocking — but nothing gated the actual notification calls in the booking-creation path. `submitBookingOrchestration`, `createPaidBookingAndNotify`, and `cancel-booking`'s route all called the real `sendBookingVerificationEmail`/`sendDriverNotificationEmail`/`notifyDriverOfNewBooking`/`sendAdminSms`/`sendSms`/`sendConfirmationEmail` unconditionally. Setting `SMOKE_TEST_MODE=true` before running the test would **not** have prevented this — there was nothing in that code path checking the flag.

Separately (same test, different symptom): the fare on that test booking looked wrong to a stakeholder. That one turned out to be a non-bug — the local emulator had no seeded `config/pricing` document, so pricing silently fell back to generic hardcoded defaults instead of the real business-configured rates, with no indication in the logs that this had happened.

## Fix

- `submitBookingOrchestration`, `createPaidBookingAndNotify`, and `cancel-booking/route.ts` now check `process.env.SMOKE_TEST_MODE === 'true'` (server-only env, never a client header — matches the pattern from #37) and skip all real email/SMS sends, logging what would have happened instead.
- `cancel-booking`'s response `channels` field now reflects reality (`[]` in smoke-test mode) instead of always hardcoding `['sms', 'email']`.
- `getPricingConfig()` now logs a loud warning when it falls back to `DEFAULT_PRICING_CONFIG`, so a mismatched quote is immediately traceable to "unseeded config," not mistaken for a pricing engine bug.
- `docs/E2E_TESTING.md` updated to explicitly instruct: always set `SMOKE_TEST_MODE=true` for any local run (automated or manual/ad hoc) that creates, pays for, or cancels a booking.

## Test plan
- [x] New regression test in `booking-server-flow.test.ts` — exercises the real, unmocked `submitBookingOrchestration` via the real `/api/booking/submit` route with `SMOKE_TEST_MODE=true`, asserts none of the 4 notification calls fire
- [x] New regression test in `cancel-booking.route.test.ts` — same assertion for the cancellation path
- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors
- [x] Full unit + integration suite — 345 passed, 5 skipped, 0 failed
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)