### PR TITLE
Fix: two Codex findings from already-merged PRs #38 and #42

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,8 +20,10 @@ if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
     exit 0
 fi
 
-# Get list of staged files
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx)$' | grep -v 'node_modules' | grep -v '\.d\.ts$' | grep -v '\.min\.js$')
+# Get list of staged files (the trailing `|| true` matters: this hook runs under `sh -e`, and
+# grep exits 1 when a commit stages no matching files — without it, that exit kills the script
+# here instead of reaching the "no files to lint" check below).
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx)$' | grep -v 'node_modules' | grep -v '\.d\.ts$' | grep -v '\.min\.js$' || true)
 
 if [ -z "$STAGED_FILES" ]; then
     echo "${GREEN}✅ No TypeScript/JavaScript files to lint${NC}"

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -72,6 +72,14 @@ production-shaped notification content, for a booking that only ever existed in 
 emulator). `SMOKE_TEST_MODE=true` makes booking creation, cancellation, and calendar/payment code
 paths skip all of those real external sends and log what would have happened instead.
 
+**This env var only takes effect on the process that actually serves the API routes.** Playwright's
+`full-flow` config uses `reuseExistingServer: !process.env.CI` locally — if you already have
+`npm run dev` running in another terminal without `SMOKE_TEST_MODE=true`, the command above starts
+Playwright with the flag set, but Playwright reuses your existing dev server instead of starting a
+new one, and that existing server still sends real notifications. Either stop any running dev
+server before running `full-flow` locally, or restart it with `SMOKE_TEST_MODE=true npm run dev`
+first.
+
 **Also seed or expect defaults for `config/pricing`.** An unseeded local Firestore (a fresh
 emulator, or a database missing that doc) falls back to `DEFAULT_PRICING_CONFIG` in
 `pricing-config.ts` — generic rates, not whatever the business has actually configured in

--- a/src/app/api/booking/get-bookings-simple/route.ts
+++ b/src/app/api/booking/get-bookings-simple/route.ts
@@ -70,8 +70,9 @@ export async function GET(request: NextRequest) {
       // Convert Firestore timestamps and format booking. `rawData.trip.pickupDateTime` is a raw
       // Firestore Timestamp (never normalized by the spread below), and the flat top-level
       // `pickupDateTime` is absent on every booking created through the normal submit flow — so
-      // both must be derived from whichever one actually has the value.
-      const normalizedPickupDateTime = safeToDate(rawData.pickupDateTime ?? rawData.trip?.pickupDateTime);
+      // both must be derived from whichever one actually has the value. Nested takes precedence
+      // over the legacy flat field, matching getBooking()/getPickupDateTime() elsewhere.
+      const normalizedPickupDateTime = safeToDate(rawData.trip?.pickupDateTime ?? rawData.pickupDateTime);
       const booking = {
         id: docSnap.id,
         ...rawData,
@@ -120,7 +121,7 @@ export async function GET(request: NextRequest) {
 
       const bookings = snapshot.docs.map((docSnap: QueryDocumentSnapshot) => {
         const data = docSnap.data();
-        const normalizedPickupDateTime = safeToDate(data.pickupDateTime ?? data.trip?.pickupDateTime);
+        const normalizedPickupDateTime = safeToDate(data.trip?.pickupDateTime ?? data.pickupDateTime);
         return {
           id: docSnap.id,
           ...data,

--- a/src/lib/services/booking-cancellation.ts
+++ b/src/lib/services/booking-cancellation.ts
@@ -61,7 +61,13 @@ export const cancelBooking = async (
 
   await driverSchedulingService.cancelBooking(bookingId);
 
-  if (options?.refundAmount != null && options.refundAmount > 0 && options.squarePaymentId) {
+  const isSmokeTest = process.env.SMOKE_TEST_MODE === 'true';
+
+  if (isSmokeTest) {
+    if (options?.refundAmount != null && options.refundAmount > 0) {
+      console.log(`🧪 Smoke test mode - skipping Square refund for booking ${bookingId}`);
+    }
+  } else if (options?.refundAmount != null && options.refundAmount > 0 && options.squarePaymentId) {
     try {
       await refundPayment(options.squarePaymentId, options.refundAmount * 100, 'USD', reason);
       console.log(`✅ Refund processed: $${options.refundAmount.toFixed(2)} for booking ${bookingId}`);

--- a/tests/unit/booking-cancellation.test.ts
+++ b/tests/unit/booking-cancellation.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { refundPayment } from '@/lib/services/square-service';
+
+const docUpdate = vi.fn().mockResolvedValue(undefined);
+const docGet = vi.fn().mockResolvedValue({ exists: true, data: () => ({}) });
+const getAdminDb = vi.fn(() => ({
+  collection: vi.fn(() => ({
+    doc: vi.fn(() => ({ get: docGet, update: docUpdate })),
+  })),
+}));
+
+vi.mock('@/lib/utils/firebase-admin', () => ({
+  getAdminDb,
+}));
+
+vi.mock('@/lib/services/square-service', () => ({
+  refundPayment: vi.fn().mockResolvedValue({ success: true, refundId: 'refund-123' }),
+}));
+
+vi.mock('@/lib/services/driver-scheduling-service', () => ({
+  driverSchedulingService: {
+    cancelBooking: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const mockRefundPayment = refundPayment as unknown as ReturnType<typeof vi.fn>;
+
+describe('cancelBooking', () => {
+  const previousSmokeTestMode = process.env.SMOKE_TEST_MODE;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    docGet.mockResolvedValue({ exists: true, data: () => ({}) });
+  });
+
+  afterEach(() => {
+    process.env.SMOKE_TEST_MODE = previousSmokeTestMode;
+  });
+
+  it('refunds via Square when a payment ID and refund amount are present', async () => {
+    process.env.SMOKE_TEST_MODE = 'false';
+    const { cancelBooking } = await import('@/lib/services/booking-cancellation');
+
+    await cancelBooking('booking-123', 'Changed plans', {
+      refundAmount: 75,
+      squarePaymentId: 'pay-123',
+      cancellationFee: 0,
+    });
+
+    expect(mockRefundPayment).toHaveBeenCalledWith('pay-123', 7500, 'USD', 'Changed plans');
+  });
+
+  it('SMOKE_TEST_MODE=true skips the Square refund entirely (regression: Codex flagged that a smoke-mode cancellation could still hit Square for real because the route only gated notifications, not this service call)', async () => {
+    process.env.SMOKE_TEST_MODE = 'true';
+    const { cancelBooking } = await import('@/lib/services/booking-cancellation');
+
+    await cancelBooking('booking-123', 'Changed plans', {
+      refundAmount: 75,
+      squarePaymentId: 'pay-123',
+      cancellationFee: 0,
+    });
+
+    expect(mockRefundPayment).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/get-bookings-simple.route.test.ts
+++ b/tests/unit/get-bookings-simple.route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const docGet = vi.fn();
+const getAdminDb = vi.fn(() => ({
+  collection: vi.fn(() => ({
+    doc: vi.fn(() => ({ get: docGet })),
+  })),
+}));
+
+vi.mock('@/lib/utils/firebase-admin', () => ({
+  getAdminDb,
+}));
+
+vi.mock('@/lib/utils/auth-server', () => ({
+  requireAuth: vi.fn().mockResolvedValue({ ok: true }),
+  requireAdmin: vi.fn().mockResolvedValue({ ok: true }),
+  requireOwnerAdminOrTrackingToken: vi.fn().mockResolvedValue({ ok: true, auth: null, access: 'tracking-token' }),
+}));
+
+const buildRequest = (bookingId: string, token = 'tok_123') =>
+  new Request(`http://localhost/api/booking/get-bookings-simple?id=${bookingId}&token=${token}`);
+
+describe('GET /api/booking/get-bookings-simple', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefers trip.pickupDateTime over a stale legacy flat pickupDateTime (regression: Codex flagged the precedence was backwards vs getBooking()/getPickupDateTime())', async () => {
+    const staleFlatDate = new Date('2020-01-01T00:00:00.000Z');
+    const currentNestedDate = new Date('2027-06-01T10:00:00.000Z');
+
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        pickupDateTime: staleFlatDate.toISOString(),
+        trip: {
+          pickupDateTime: currentNestedDate.toISOString(),
+        },
+      }),
+    });
+
+    const { GET } = await import('@/app/api/booking/get-bookings-simple/route');
+    const response = await GET(buildRequest('booking-123') as any);
+    const payload = await response!.json();
+
+    expect(payload.success).toBe(true);
+    expect(payload.booking.pickupDateTime).toBe(currentNestedDate.toISOString());
+    expect(payload.booking.trip.pickupDateTime).toBe(currentNestedDate.toISOString());
+  });
+
+  it('falls back to the legacy flat pickupDateTime when trip.pickupDateTime is absent', async () => {
+    const flatDate = new Date('2027-06-01T10:00:00.000Z');
+
+    docGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        pickupDateTime: flatDate.toISOString(),
+      }),
+    });
+
+    const { GET } = await import('@/app/api/booking/get-bookings-simple/route');
+    const response = await GET(buildRequest('booking-456') as any);
+    const payload = await response!.json();
+
+    expect(payload.success).toBe(true);
+    expect(payload.booking.pickupDateTime).toBe(flatDate.toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
PRs #38 and #42 were merged directly to `main` without reading the Codex review comments left on them. Went back, verified each finding against current `main`, and fixed all three:

- **`booking-cancellation.ts`** — `SMOKE_TEST_MODE` only gated the notification calls in `cancel-booking/route.ts`; `cancelBooking()` itself called Square's `refundPayment()` unconditionally whenever a `squarePaymentId` was present. A smoke-test cancellation run against a booking with a real payment ID could still issue a real refund. Added the same smoke-test check the calendar-deletion branch in the same file already uses. (PR #42, Codex P1)
- **`get-bookings-simple/route.ts`** — the pickup-time normalization added in PR #38 preferred the legacy flat `pickupDateTime` over `trip.pickupDateTime`, the opposite precedence used everywhere else (`getBooking()`, `getPickupDateTime()` helpers). A booking with a stale flat field and an updated nested one would show/use the wrong pickup time through this endpoint. Flipped both occurrences (single-booking and list) to match established precedence. (PR #38, Codex P2)
- **`docs/E2E_TESTING.md`** — clarified that `SMOKE_TEST_MODE=true` only takes effect on the process actually serving the API; Playwright's `reuseExistingServer: !process.env.CI` means an already-running `npm run dev` (started without the flag) gets reused instead, silently defeating the instruction. (PR #42, Codex P2)

Also fixed a real, unrelated bug hit while committing this: `.husky/pre-commit` runs under `sh -e`, and its `grep -E '\.(ts|tsx|js|jsx)$'` exits 1 on zero matches — which under `-e` killed the whole hook before it reached its own "no files to lint" check, on any commit staging only non-JS/TS files (like the docs-only commit here).

## Test plan
- [x] New regression test (`tests/unit/booking-cancellation.test.ts`) proves `SMOKE_TEST_MODE=true` skips the Square refund call; fails on pre-fix code
- [x] New regression test (`tests/unit/get-bookings-simple.route.test.ts`) proves `trip.pickupDateTime` wins over a stale flat field; fails on pre-fix code
- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors
- [x] Full unit + integration suite — 353 passed, 5 skipped, 0 failed
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)