### PR TITLE
feat: configurable minimum fare floor

### DIFF
--- a/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
+++ b/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
@@ -12,6 +12,7 @@ interface PricingForm {
   perMinute: number;
   airportReturnMultiplier: number;
   personalDiscountPercent: number;
+  minimumFare: number;
   updatedAt?: string;
   version?: number;
 }
@@ -29,6 +30,8 @@ interface TestQuoteResult {
     personalDiscount: number | null;
     returnMultiplier: number | null;
     preMultiplierFare: number | null;
+    minimumFare: number;
+    minimumFareApplied: boolean;
   };
   isAirportPickup: boolean;
   isAirportDropoff: boolean;
@@ -41,6 +44,7 @@ const DEFAULT_FORM: PricingForm = {
   perMinute: 0.20,
   airportReturnMultiplier: 1.15,
   personalDiscountPercent: 10,
+  minimumFare: 100,
 };
 
 export default function AdminPricingPageClient() {
@@ -70,6 +74,7 @@ export default function AdminPricingPageClient() {
           perMinute: data.perMinute ?? DEFAULT_FORM.perMinute,
           airportReturnMultiplier: data.airportReturnMultiplier ?? DEFAULT_FORM.airportReturnMultiplier,
           personalDiscountPercent: data.personalDiscountPercent ?? DEFAULT_FORM.personalDiscountPercent,
+          minimumFare: data.minimumFare ?? DEFAULT_FORM.minimumFare,
           updatedAt: data.updatedAt as string | undefined,
           version: data.version as number | undefined,
         });
@@ -91,6 +96,7 @@ export default function AdminPricingPageClient() {
         perMinute: form.perMinute,
         airportReturnMultiplier: form.airportReturnMultiplier,
         personalDiscountPercent: form.personalDiscountPercent,
+        minimumFare: form.minimumFare,
       }),
     })
       .then((res) => res.ok ? undefined : res.json().then((e) => Promise.reject(new Error(e.error || 'Save failed'))))
@@ -128,6 +134,7 @@ export default function AdminPricingPageClient() {
           perMinute: form.perMinute,
           airportReturnMultiplier: form.airportReturnMultiplier,
           personalDiscountPercent: form.personalDiscountPercent,
+          minimumFare: form.minimumFare,
         },
       }),
     })
@@ -174,6 +181,9 @@ export default function AdminPricingPageClient() {
               </Text>
               <Text size="sm">
                 <Text as="span" weight="bold">Return trips</Text> (airport pickup to home): fare multiplied by x{form.airportReturnMultiplier.toFixed(2)}
+              </Text>
+              <Text size="sm">
+                <Text as="span" weight="bold">Minimum fare:</Text> ${form.minimumFare.toFixed(2)} — applied last, after any discount or multiplier above. No ride is ever charged less than this.
               </Text>
             </Stack>
           </Stack>
@@ -241,7 +251,17 @@ export default function AdminPricingPageClient() {
                   onChange={(e) => updateField('personalDiscountPercent', Number(e.target.value) || 0)}
                 />
               </div>
-              <div style={{ flex: 1 }} />
+              <div style={{ flex: 1 }}>
+                <Label>Minimum fare ($)</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={500}
+                  step={5}
+                  value={String(form.minimumFare)}
+                  onChange={(e) => updateField('minimumFare', Number(e.target.value) || 0)}
+                />
+              </div>
             </Stack>
             <Stack spacing="md" direction="horizontal">
               <Button variant="primary" onClick={handleSave} disabled={saving} text={saving ? 'Saving...' : 'Save pricing'} />
@@ -341,6 +361,11 @@ export default function AdminPricingPageClient() {
                       {testResult.breakdown.returnMultiplier != null && (
                         <Text size="sm" style={{ fontFamily: 'monospace', color: '#d97706' }}>
                           Return trip (x{testResult.breakdown.returnMultiplier}): ${testResult.breakdown.preMultiplierFare?.toFixed(2)} → ${testResult.fare.toFixed(2)}
+                        </Text>
+                      )}
+                      {testResult.breakdown.minimumFareApplied && (
+                        <Text size="sm" style={{ fontFamily: 'monospace', color: '#d97706' }}>
+                          Minimum fare (${testResult.breakdown.minimumFare.toFixed(2)}) applied — calculated fare was below the floor
                         </Text>
                       )}
                     </Stack>

--- a/src/app/api/admin/pricing/test-quote/route.ts
+++ b/src/app/api/admin/pricing/test-quote/route.ts
@@ -29,6 +29,7 @@ export async function POST(request: NextRequest) {
       perMinute: pricingOverrides?.perMinute ?? savedConfig.perMinute,
       airportReturnMultiplier: pricingOverrides?.airportReturnMultiplier ?? savedConfig.airportReturnMultiplier,
       personalDiscountPercent: pricingOverrides?.personalDiscountPercent ?? savedConfig.personalDiscountPercent,
+      minimumFare: pricingOverrides?.minimumFare ?? savedConfig.minimumFare,
     };
 
     // Always geocode the address text, same as the real quote endpoint (quote/route.ts) — using
@@ -83,9 +84,11 @@ export async function POST(request: NextRequest) {
     }
 
     const subtotal = Math.ceil(rawFare);
+    const minimumFareApplied = pricing.minimumFare > 0 && subtotal < pricing.minimumFare;
+    const fare = minimumFareApplied ? pricing.minimumFare : subtotal;
 
     return NextResponse.json({
-      fare: subtotal,
+      fare,
       distanceMiles: Math.round(distanceMiles * 100) / 100,
       durationMinutes: Math.round(durationMinutes),
       durationTrafficMinutes: Math.round(durationTrafficMinutes),
@@ -97,6 +100,8 @@ export async function POST(request: NextRequest) {
         personalDiscount: personalDiscount > 0 ? Math.round(personalDiscount * 100) / 100 : null,
         returnMultiplier: returnMultiplierApplied ? pricing.airportReturnMultiplier : null,
         preMultiplierFare: returnMultiplierApplied ? Math.ceil(preMultiplierFare) : null,
+        minimumFare: pricing.minimumFare,
+        minimumFareApplied,
       },
       isAirportPickup,
       isAirportDropoff,

--- a/src/app/api/admin/pricing/test-quote/route.ts
+++ b/src/app/api/admin/pricing/test-quote/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Client } from '@googlemaps/google-maps-services-js';
-import { getPricingConfig } from '@/lib/business/pricing-config';
+import { applyMinimumFare, getPricingConfig } from '@/lib/business/pricing-config';
 import { requireAdmin } from '@/lib/utils/auth-server';
 import { isAirportLocation } from '@/lib/services/service-area-validation';
 
@@ -84,8 +84,7 @@ export async function POST(request: NextRequest) {
     }
 
     const subtotal = Math.ceil(rawFare);
-    const minimumFareApplied = pricing.minimumFare > 0 && subtotal < pricing.minimumFare;
-    const fare = minimumFareApplied ? pricing.minimumFare : subtotal;
+    const { fare, minimumFareApplied } = applyMinimumFare(subtotal, pricing.minimumFare);
 
     return NextResponse.json({
       fare,

--- a/src/app/api/booking/quote/route.ts
+++ b/src/app/api/booking/quote/route.ts
@@ -42,6 +42,7 @@ export async function POST(request: Request) {
     perMinute: PER_MINUTE_RATE,
     personalDiscountPercent,
     airportReturnMultiplier,
+    minimumFare: MINIMUM_FARE,
   } = settings;
 
   // Validate pickup time is in the future
@@ -143,7 +144,9 @@ export async function POST(request: Request) {
     rawFare = rawFare * multiplier;
   }
 
-  let fare = Math.ceil(rawFare);
+  // Floor applies last, after every discount/multiplier — it's the absolute minimum a customer
+  // is ever charged, not another input to the formula above it.
+  const fare = Math.max(Math.ceil(rawFare), MINIMUM_FARE);
 
   // Check availability for the requested time slot
   let availabilityWarning: string | null = null;
@@ -207,7 +210,8 @@ export async function POST(request: Request) {
       expiresAt: expiresAt.toISOString(),
       expiresInMinutes: 15,
       availabilityWarning,
-      suggestedTimes
+      suggestedTimes,
+      minimumFare: MINIMUM_FARE,
     });
     return NextResponse.json(responseBody);
   } catch (error) {
@@ -220,7 +224,8 @@ export async function POST(request: Request) {
       expiresAt: expiresAt.toISOString(),
       expiresInMinutes: 15,
       availabilityWarning,
-      suggestedTimes
+      suggestedTimes,
+      minimumFare: MINIMUM_FARE,
     });
     return NextResponse.json(responseBody);
   }

--- a/src/app/api/booking/quote/route.ts
+++ b/src/app/api/booking/quote/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Client } from '@googlemaps/google-maps-services-js';
 import { getSettings } from '@/lib/business/settings-service';
+import { applyMinimumFare } from '@/lib/business/pricing-config';
 import { createQuote } from '@/lib/services/quote-service';
 import { driverSchedulingService } from '@/lib/services/driver-scheduling-service';
 import { classifyTrip, isAirportLocation } from '@/lib/services/service-area-validation';
@@ -146,7 +147,7 @@ export async function POST(request: Request) {
 
   // Floor applies last, after every discount/multiplier — it's the absolute minimum a customer
   // is ever charged, not another input to the formula above it.
-  const fare = Math.max(Math.ceil(rawFare), MINIMUM_FARE);
+  const { fare, minimumFareApplied } = applyMinimumFare(Math.ceil(rawFare), MINIMUM_FARE);
 
   // Check availability for the requested time slot
   let availabilityWarning: string | null = null;
@@ -212,6 +213,7 @@ export async function POST(request: Request) {
       availabilityWarning,
       suggestedTimes,
       minimumFare: MINIMUM_FARE,
+      minimumFareApplied,
     });
     return NextResponse.json(responseBody);
   } catch (error) {
@@ -226,6 +228,7 @@ export async function POST(request: Request) {
       availabilityWarning,
       suggestedTimes,
       minimumFare: MINIMUM_FARE,
+      minimumFareApplied,
     });
     return NextResponse.json(responseBody);
   }

--- a/src/components/booking/TripDetailsPhase.tsx
+++ b/src/components/booking/TripDetailsPhase.tsx
@@ -122,6 +122,7 @@ export function TripDetailsPhase({
           fareType={tripData.fareType}
           cmsData={cmsData}
           error={fareError}
+          minimumFare={currentQuote?.minimumFare}
         />
 
         {/* Error States */}

--- a/src/components/booking/TripDetailsPhase.tsx
+++ b/src/components/booking/TripDetailsPhase.tsx
@@ -123,6 +123,7 @@ export function TripDetailsPhase({
           cmsData={cmsData}
           error={fareError}
           minimumFare={currentQuote?.minimumFare}
+          minimumFareApplied={currentQuote?.minimumFareApplied}
         />
 
         {/* Error States */}

--- a/src/components/booking/trip-details/FareDisplaySection.tsx
+++ b/src/components/booking/trip-details/FareDisplaySection.tsx
@@ -11,6 +11,7 @@ interface FareDisplaySectionProps {
   fareType: 'personal' | 'business';
   cmsData: any;
   error?: string | null;
+  minimumFare?: number | null;
 }
 
 export const FareDisplaySection: React.FC<FareDisplaySectionProps> = ({
@@ -18,7 +19,8 @@ export const FareDisplaySection: React.FC<FareDisplaySectionProps> = ({
   isCalculating,
   fareType,
   cmsData,
-  error
+  error,
+  minimumFare
 }) => {
   const formatFare = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -78,9 +80,18 @@ export const FareDisplaySection: React.FC<FareDisplaySectionProps> = ({
           </Text>
         </Stack>
         
+        {minimumFare != null && minimumFare > 0 && (
+          <Text size="sm" color="secondary" data-testid="minimum-fare-notice">
+            {(cmsData?.['tripDetailsPhase-minimumFareNotice'] as string | undefined)?.replace(
+              '{amount}',
+              formatFare(minimumFare)
+            ) || `A ${formatFare(minimumFare)} minimum fare applies to all rides.`}
+          </Text>
+        )}
+
         {/* Countdown for quote validity if available */}
         <CountdownRow />
-        
+
         {/* Price Guarantee - Temporarily hidden */}
         {/* <PriceGuarantee variant="full" cmsData={cmsData} /> */}
       </Stack>

--- a/src/components/booking/trip-details/FareDisplaySection.tsx
+++ b/src/components/booking/trip-details/FareDisplaySection.tsx
@@ -12,6 +12,7 @@ interface FareDisplaySectionProps {
   cmsData: any;
   error?: string | null;
   minimumFare?: number | null;
+  minimumFareApplied?: boolean;
 }
 
 export const FareDisplaySection: React.FC<FareDisplaySectionProps> = ({
@@ -20,7 +21,8 @@ export const FareDisplaySection: React.FC<FareDisplaySectionProps> = ({
   fareType,
   cmsData,
   error,
-  minimumFare
+  minimumFare,
+  minimumFareApplied
 }) => {
   const formatFare = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -80,12 +82,12 @@ export const FareDisplaySection: React.FC<FareDisplaySectionProps> = ({
           </Text>
         </Stack>
         
-        {minimumFare != null && minimumFare > 0 && (
+        {minimumFareApplied && minimumFare != null && minimumFare > 0 && (
           <Text size="sm" color="secondary" data-testid="minimum-fare-notice">
             {(cmsData?.['tripDetailsPhase-minimumFareNotice'] as string | undefined)?.replace(
               '{amount}',
               formatFare(minimumFare)
-            ) || `A ${formatFare(minimumFare)} minimum fare applies to all rides.`}
+            ) || `Our ${formatFare(minimumFare)} minimum fare applies to this ride.`}
           </Text>
         )}
 

--- a/src/lib/business/pricing-config.ts
+++ b/src/lib/business/pricing-config.ts
@@ -11,6 +11,10 @@ export const pricingConfigSchema = z.object({
   perMinute: z.number().min(0).max(10),
   airportReturnMultiplier: z.number().min(1).max(5),
   personalDiscountPercent: z.number().min(0).max(100),
+  // The absolute minimum a customer is ever charged, applied after every other stage (base +
+  // mileage + time, personal discount, airport multiplier) — a short or nearby ride must never
+  // price out below this floor regardless of what the formula above it computes.
+  minimumFare: z.number().min(0).max(500).default(0),
   updatedAt: z.union([z.date(), z.string()]).optional(),
   updatedBy: z.string().optional(),
   version: z.number().int().min(1).optional(),
@@ -24,6 +28,7 @@ export const DEFAULT_PRICING_CONFIG: PricingConfig = {
   perMinute: 0.20,
   airportReturnMultiplier: 1.15,
   personalDiscountPercent: 10,
+  minimumFare: 100,
   version: 1,
 };
 

--- a/src/lib/business/pricing-config.ts
+++ b/src/lib/business/pricing-config.ts
@@ -13,8 +13,11 @@ export const pricingConfigSchema = z.object({
   personalDiscountPercent: z.number().min(0).max(100),
   // The absolute minimum a customer is ever charged, applied after every other stage (base +
   // mileage + time, personal discount, airport multiplier) — a short or nearby ride must never
-  // price out below this floor regardless of what the formula above it computes.
-  minimumFare: z.number().min(0).max(500).default(0),
+  // price out below this floor regardless of what the formula above it computes. Defaults to
+  // DEFAULT_PRICING_CONFIG's value below (not 0) so an existing config/pricing doc that predates
+  // this field gets the floor applied too, not silently no floor until an admin happens to
+  // re-save the pricing page.
+  minimumFare: z.number().min(0).max(500).default(100),
   updatedAt: z.union([z.date(), z.string()]).optional(),
   updatedBy: z.string().optional(),
   version: z.number().int().min(1).optional(),

--- a/src/lib/business/pricing-config.ts
+++ b/src/lib/business/pricing-config.ts
@@ -16,8 +16,10 @@ export const pricingConfigSchema = z.object({
   // price out below this floor regardless of what the formula above it computes. Defaults to
   // DEFAULT_PRICING_CONFIG's value below (not 0) so an existing config/pricing doc that predates
   // this field gets the floor applied too, not silently no floor until an admin happens to
-  // re-save the pricing page.
-  minimumFare: z.number().min(0).max(500).default(100),
+  // re-save the pricing page. Whole dollars only — every other fare in the pipeline is ceil'd to
+  // a whole dollar exactly once at the end, and a fractional floor could otherwise win Math.max
+  // and produce a fractional final fare (see applyMinimumFare, which also ceils defensively).
+  minimumFare: z.number().int().min(0).max(500).default(100),
   updatedAt: z.union([z.date(), z.string()]).optional(),
   updatedBy: z.string().optional(),
   version: z.number().int().min(1).optional(),
@@ -86,6 +88,25 @@ export async function getPricingConfig(): Promise<PricingConfig> {
  */
 export function invalidatePricingCache(): void {
   cached = null;
+}
+
+/**
+ * Apply the minimum-fare floor to an already-ceil'd whole-dollar fare. Shared by the real quote
+ * endpoint and the admin test-quote preview so the two can't silently drift on how the floor is
+ * applied (they previously each computed and rounded the pre-floor pipeline independently, which
+ * is exactly the class of bug the "single ceil at the end" fix elsewhere in this file addresses).
+ * Ceils minimumFare defensively — the schema already requires a whole-dollar int, but this keeps
+ * the "final fare is always a whole dollar" guarantee even if that ever changes.
+ */
+export function applyMinimumFare(
+  fare: number,
+  minimumFare: number
+): { fare: number; minimumFareApplied: boolean } {
+  const flooredMinimum = Math.ceil(minimumFare);
+  if (flooredMinimum > 0 && fare < flooredMinimum) {
+    return { fare: flooredMinimum, minimumFareApplied: true };
+  }
+  return { fare, minimumFareApplied: false };
 }
 
 /**

--- a/src/lib/business/settings-service.ts
+++ b/src/lib/business/settings-service.ts
@@ -11,5 +11,6 @@ export async function getSettings(): Promise<Settings> {
     perMinute: pricing.perMinute,
     personalDiscountPercent: pricing.personalDiscountPercent,
     airportReturnMultiplier: pricing.airportReturnMultiplier,
+    minimumFare: pricing.minimumFare,
   };
 }

--- a/src/lib/contracts/booking-api.ts
+++ b/src/lib/contracts/booking-api.ts
@@ -88,6 +88,7 @@ export const quoteResponseSchema = z.object({
   expiresInMinutes: z.number(),
   availabilityWarning: z.string().nullable().optional(),
   suggestedTimes: z.array(z.string()).optional(),
+  minimumFare: z.number().optional(),
 });
 
 export const submitBookingRequestSchema = z.object({

--- a/src/lib/contracts/booking-api.ts
+++ b/src/lib/contracts/booking-api.ts
@@ -89,6 +89,7 @@ export const quoteResponseSchema = z.object({
   availabilityWarning: z.string().nullable().optional(),
   suggestedTimes: z.array(z.string()).optional(),
   minimumFare: z.number().optional(),
+  minimumFareApplied: z.boolean().optional(),
 });
 
 export const submitBookingRequestSchema = z.object({

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -200,7 +200,9 @@ export interface QuoteData {
   fareType: 'personal' | 'business';
   expiresAt: string;  // ISO datetime string
   expiresInMinutes: number;
-  // The minimum fare floor applied to this quote (0 if none configured) — surfaced so the
-  // booking flow can tell the customer up front, not just silently clamp a short ride's price.
+  // The minimum fare floor configured at quote time, and whether it actually clamped THIS fare —
+  // surfaced so the booking flow can tell the customer only when it's actually relevant, not show
+  // a blanket "minimum fare applies" note on every quote regardless of whether it took effect.
   minimumFare?: number;
+  minimumFareApplied?: boolean;
 }

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -200,4 +200,7 @@ export interface QuoteData {
   fareType: 'personal' | 'business';
   expiresAt: string;  // ISO datetime string
   expiresInMinutes: number;
+  // The minimum fare floor applied to this quote (0 if none configured) — surfaced so the
+  // booking flow can tell the customer up front, not just silently clamp a short ride's price.
+  minimumFare?: number;
 }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
   perMinute: number;        // dollars per minute
   personalDiscountPercent: number; // % discount for personal rides
   airportReturnMultiplier: number; // multiplier for airport-to-home rides
+  minimumFare: number;      // absolute floor a customer is ever charged, dollars
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -19,4 +20,5 @@ export const DEFAULT_SETTINGS: Settings = {
   perMinute: 0.20,
   personalDiscountPercent: 10,
   airportReturnMultiplier: 1.15,
+  minimumFare: 100,
 };

--- a/tests/integration/canonical-endpoints.contract.test.ts
+++ b/tests/integration/canonical-endpoints.contract.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/lib/business/settings-service', () => ({
     perMile: 2,
     perMinute: 1,
     airportReturnMultiplier: 1.8,
+    minimumFare: 0,
   }),
 }));
 

--- a/tests/unit/admin-pricing-test-quote.route.test.ts
+++ b/tests/unit/admin-pricing-test-quote.route.test.ts
@@ -11,9 +11,13 @@ vi.mock('@googlemaps/google-maps-services-js', () => ({
   }),
 }));
 
-vi.mock('@/lib/business/pricing-config', () => ({
-  getPricingConfig: mockGetPricingConfig,
-}));
+vi.mock('@/lib/business/pricing-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/business/pricing-config')>();
+  return {
+    ...actual,
+    getPricingConfig: mockGetPricingConfig,
+  };
+});
 
 vi.mock('@/lib/utils/auth-server', () => ({
   requireAdmin: mockRequireAdmin,

--- a/tests/unit/admin-pricing-test-quote.route.test.ts
+++ b/tests/unit/admin-pricing-test-quote.route.test.ts
@@ -46,6 +46,7 @@ describe('POST /api/admin/pricing/test-quote', () => {
       perMinute: 0.5,
       airportReturnMultiplier: 1.15,
       personalDiscountPercent: 10,
+      minimumFare: 0,
     });
     mockIsAirportLocation.mockReturnValue(false);
     mockDistanceMatrix.mockResolvedValue({

--- a/tests/unit/booking-quote.route.test.ts
+++ b/tests/unit/booking-quote.route.test.ts
@@ -208,6 +208,7 @@ describe('POST /api/booking/quote', () => {
 
     expect(payload.fare).toBe(100);
     expect(payload.minimumFare).toBe(100);
+    expect(payload.minimumFareApplied).toBe(true);
   });
 
   it('does not reduce a fare that is already above the minimum', async () => {
@@ -234,5 +235,31 @@ describe('POST /api/booking/quote', () => {
     // With the beforeEach distance/duration mock (10 mi, 40 min traffic): 20 + 10*2 + 40*0.5 = 60,
     // well above the 30 floor — the floor must not clamp it down to 30.
     expect(payload.fare).toBe(60);
+    expect(payload.minimumFareApplied).toBe(false);
+  });
+
+  it('rounds a fractional minimumFare up to a whole dollar (regression: Math.max(ceiledFare, minimumFare) could return a fractional final fare if minimumFare itself was fractional and won the comparison, breaking the "always whole dollars" invariant every other fare respects)', async () => {
+    const pickupTime = new Date(Date.now() + 26 * 60 * 60 * 1000).toISOString();
+    mockGetSettings.mockResolvedValue({
+      baseFare: 5,
+      perMile: 0,
+      perMinute: 0,
+      airportReturnMultiplier: 1.15,
+      personalDiscountPercent: 0,
+      minimumFare: 99.5,
+    });
+
+    const response = await POST(
+      buildRequest({
+        origin: 'Fairfield Station, Fairfield, CT',
+        destination: 'JFK Airport, Queens, NY',
+        fareType: 'business',
+        pickupTime,
+      })
+    );
+    const payload = await response.json();
+
+    expect(payload.fare).toBe(100);
+    expect(Number.isInteger(payload.fare)).toBe(true);
   });
 });

--- a/tests/unit/booking-quote.route.test.ts
+++ b/tests/unit/booking-quote.route.test.ts
@@ -61,6 +61,7 @@ describe('POST /api/booking/quote', () => {
       perMile: 2,
       perMinute: 0.5,
       airportReturnMultiplier: 1.8,
+      minimumFare: 0,
     });
     mockClassifyTrip.mockReturnValue({
       classification: 'normal',
@@ -165,6 +166,7 @@ describe('POST /api/booking/quote', () => {
       perMinute: 0,
       airportReturnMultiplier: 1.09,
       personalDiscountPercent: 0,
+      minimumFare: 0,
     });
     mockIsAirportLocation.mockImplementation((address: string) => address === 'JFK Airport, Queens, NY');
 
@@ -180,5 +182,57 @@ describe('POST /api/booking/quote', () => {
 
     // Old per-stage-ceil behavior would have produced ceil(ceil(10.01) * 1.09) = ceil(11.99) = 12.
     expect(payload.fare).toBe(11);
+  });
+
+  it('raises a short/nearby ride up to the configured minimum fare (regression: no floor existed, so a 2-minute local hop could price out far below what covers dispatching a driver)', async () => {
+    const pickupTime = new Date(Date.now() + 26 * 60 * 60 * 1000).toISOString();
+    // Zeroed mileage/time rates so the raw calculated fare (just baseFare) is well under the floor.
+    mockGetSettings.mockResolvedValue({
+      baseFare: 5,
+      perMile: 0,
+      perMinute: 0,
+      airportReturnMultiplier: 1.15,
+      personalDiscountPercent: 0,
+      minimumFare: 100,
+    });
+
+    const response = await POST(
+      buildRequest({
+        origin: 'Fairfield Station, Fairfield, CT',
+        destination: 'JFK Airport, Queens, NY',
+        fareType: 'business',
+        pickupTime,
+      })
+    );
+    const payload = await response.json();
+
+    expect(payload.fare).toBe(100);
+    expect(payload.minimumFare).toBe(100);
+  });
+
+  it('does not reduce a fare that is already above the minimum', async () => {
+    const pickupTime = new Date(Date.now() + 26 * 60 * 60 * 1000).toISOString();
+    mockGetSettings.mockResolvedValue({
+      baseFare: 20,
+      perMile: 2,
+      perMinute: 0.5,
+      airportReturnMultiplier: 1.15,
+      personalDiscountPercent: 0,
+      minimumFare: 30,
+    });
+
+    const response = await POST(
+      buildRequest({
+        origin: 'Fairfield Station, Fairfield, CT',
+        destination: 'JFK Airport, Queens, NY',
+        fareType: 'business',
+        pickupTime,
+      })
+    );
+    const payload = await response.json();
+
+    // With the beforeEach distance/duration mock (10 mi, 40 min traffic): 20 + 10*2 + 40*0.5 = 60,
+    // well above the 30 floor — the floor must not clamp it down to 30.
+    expect(payload.fare).toBe(60);
   });
 });

--- a/tests/unit/pricing-config.test.ts
+++ b/tests/unit/pricing-config.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAdminDb = vi.fn();
+
+vi.mock('@/lib/utils/firebase-admin', () => ({
+  getAdminDb: () => getAdminDb(),
+}));
+
+let getPricingConfig: typeof import('@/lib/business/pricing-config').getPricingConfig;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  ({ getPricingConfig } = await import('@/lib/business/pricing-config'));
+});
+
+function mockDoc(data: Record<string, unknown> | undefined) {
+  getAdminDb.mockReturnValue({
+    collection: () => ({
+      doc: () => ({
+        get: async () => ({
+          exists: data !== undefined,
+          data: () => data,
+        }),
+      }),
+    }),
+  });
+}
+
+describe('getPricingConfig — minimumFare default', () => {
+  it('defaults minimumFare to 100 for a config/pricing doc that predates the field (regression: the zod schema defaulted the missing field to 0, silently disabling the floor for every existing production config until an admin happened to re-save the pricing page)', async () => {
+    mockDoc({
+      baseFare: 15,
+      perMile: 1.8,
+      perMinute: 0.2,
+      airportReturnMultiplier: 1.15,
+      personalDiscountPercent: 10,
+      // no minimumFare field — simulates a doc written before this field existed
+    });
+
+    const config = await getPricingConfig();
+
+    expect(config.minimumFare).toBe(100);
+  });
+
+  it('respects an explicit minimumFare of 0 saved by an admin (deliberately disabling the floor)', async () => {
+    mockDoc({
+      baseFare: 15,
+      perMile: 1.8,
+      perMinute: 0.2,
+      airportReturnMultiplier: 1.15,
+      personalDiscountPercent: 10,
+      minimumFare: 0,
+    });
+
+    const config = await getPricingConfig();
+
+    expect(config.minimumFare).toBe(0);
+  });
+
+  it('respects an explicit non-default minimumFare saved by an admin', async () => {
+    mockDoc({
+      baseFare: 15,
+      perMile: 1.8,
+      perMinute: 0.2,
+      airportReturnMultiplier: 1.15,
+      personalDiscountPercent: 10,
+      minimumFare: 75,
+    });
+
+    const config = await getPricingConfig();
+
+    expect(config.minimumFare).toBe(75);
+  });
+});

--- a/tests/unit/pricing-config.test.ts
+++ b/tests/unit/pricing-config.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyMinimumFare } from '@/lib/business/pricing-config';
 
 const getAdminDb = vi.fn();
 
@@ -71,5 +72,24 @@ describe('getPricingConfig — minimumFare default', () => {
     const config = await getPricingConfig();
 
     expect(config.minimumFare).toBe(75);
+  });
+});
+
+describe('applyMinimumFare — shared floor logic (used by both the real quote endpoint and the admin test-quote preview so they can\'t silently drift on how the floor is applied)', () => {
+  it('raises a fare below the floor, and reports it as applied', () => {
+    expect(applyMinimumFare(45, 100)).toEqual({ fare: 100, minimumFareApplied: true });
+  });
+
+  it('leaves a fare at or above the floor unchanged, and reports it as not applied', () => {
+    expect(applyMinimumFare(150, 100)).toEqual({ fare: 150, minimumFareApplied: false });
+    expect(applyMinimumFare(100, 100)).toEqual({ fare: 100, minimumFareApplied: false });
+  });
+
+  it('treats a configured floor of 0 as "no floor" rather than clamping everything to 0', () => {
+    expect(applyMinimumFare(45, 0)).toEqual({ fare: 45, minimumFareApplied: false });
+  });
+
+  it('ceils a fractional minimumFare so the result is always a whole dollar (regression: a fractional floor could win Math.max and produce a fractional final fare)', () => {
+    expect(applyMinimumFare(45, 99.5)).toEqual({ fare: 100, minimumFareApplied: true });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a `minimumFare` field to pricing config (default $100) — applied last, after every discount/multiplier, so a short or nearby ride is never charged less than the floor.
- Existing production pricing configs (which predate this field) get the $100 default applied too, not silently disabled until someone re-saves the pricing page.
- Admin pricing page gets a "Minimum fare" input alongside the other rate fields; the quote-tester breakdown shows when the floor kicked in.
- Customers see a "minimum fare applies" note in the booking flow, but only on quotes the floor actually affected — not on every quote regardless of relevance.
- Fare-floor logic is centralized in one shared `applyMinimumFare()` helper used by both the real quote endpoint and the admin preview, so the two can't silently drift.

This went through both required pre-PR review passes (yp-staff-review + code-review) before opening; all findings from both were fixed and verified.

## Test plan
- [x] `npm run type-check` clean
- [x] Full unit + integration suite passing (pre-push hook)
- [x] Build passing (pre-push hook)
- [x] New regression tests: `tests/unit/pricing-config.test.ts` (schema default backfill, `applyMinimumFare` logic), `tests/unit/booking-quote.route.test.ts` (floor raises a low fare, doesn't reduce a high one, whole-dollar rounding)
- [ ] Manual: confirm the "Minimum fare" field appears on `/admin/pricing` and the customer notice only shows when the floor is actually hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)