### PR TITLE
feat: batch-test common routes on the admin pricing page

### DIFF
--- a/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
+++ b/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Container, Stack, Text, Box, Button, Input, Label, LoadingSpinner, Alert, H1, H2 } from '@/design/ui';
 import { LocationInput } from '@/design/components/base-components/forms/LocationInput';
 import { authFetch } from '@/lib/utils/auth-fetch';
@@ -48,13 +48,7 @@ const DEFAULT_FORM: PricingForm = {
   minimumFare: 100,
 };
 
-interface CommonPickup {
-  label: string;
-  address: string;
-  coords: { lat: number; lng: number };
-}
-
-interface CommonAirport {
+interface CommonLocation {
   label: string;
   address: string;
   coords: { lat: number; lng: number };
@@ -63,41 +57,86 @@ interface CommonAirport {
 // The pickup points Gregg's customers actually book most often. Label and address intentionally
 // match (both plain town names) — Google resolves these to the town centroid, so a label implying
 // a specific landmark (e.g. "train station") would overstate precision the query doesn't have.
-const COMMON_PICKUPS: CommonPickup[] = [
+const COMMON_PICKUPS: CommonLocation[] = [
   { label: 'Fairfield, CT', address: 'Fairfield, CT', coords: { lat: 41.1408, lng: -73.2633 } },
   { label: 'Westport, CT', address: 'Westport, CT', coords: { lat: 41.1415, lng: -73.3579 } },
   { label: 'Stamford, CT', address: 'Stamford, CT', coords: { lat: 41.0534, lng: -73.5387 } },
   { label: 'Trumbull, CT', address: 'Trumbull, CT', coords: { lat: 41.2429, lng: -73.2007 } },
 ];
 
-// A curated, geocodable full address per airport (KNOWN_AIRPORTS' bare `name` is enough for some
-// of these, but a city/state suffix makes the Distance Matrix lookup more reliable) — coordinates
-// are derived from KNOWN_AIRPORTS itself (single source of truth) rather than re-typed here, so
-// this can't silently drift if an airport's reference coordinates are ever tuned in constants.ts.
-const COMMON_AIRPORT_ADDRESSES: Record<string, string> = {
-  JFK: 'John F. Kennedy International Airport, Queens, NY',
-  LGA: 'LaGuardia Airport, Queens, NY 11371',
-  EWR: 'Newark Liberty International Airport, Newark, NJ',
-  BDL: 'Bradley International Airport, Windsor Locks, CT',
-  HVN: 'Tweed New Haven Airport, New Haven, CT',
-  HPN: 'Westchester County Airport, White Plains, NY',
+// City/state suffix per airport for a reliably-geocodable full address — the airport NAME itself
+// is derived from KNOWN_AIRPORTS.name (not re-typed) so it can't drift from the airport-detection
+// logic's own reference data; only this small suffix map is curated locally.
+const COMMON_AIRPORT_ADDRESS_SUFFIXES: Record<string, string> = {
+  JFK: 'Queens, NY',
+  LGA: 'Queens, NY 11371',
+  EWR: 'Newark, NJ',
+  BDL: 'Windsor Locks, CT',
+  HVN: 'New Haven, CT',
+  HPN: 'White Plains, NY',
 };
 
-const COMMON_AIRPORTS: CommonAirport[] = KNOWN_AIRPORTS.filter((a) => a.code in COMMON_AIRPORT_ADDRESSES).map(
-  (a) => ({ label: a.code, address: COMMON_AIRPORT_ADDRESSES[a.code], coords: a.coordinates })
+const COMMON_AIRPORTS: CommonLocation[] = KNOWN_AIRPORTS.filter((a) => a.code in COMMON_AIRPORT_ADDRESS_SUFFIXES).map(
+  (a) => ({ label: a.code, address: `${a.name}, ${COMMON_AIRPORT_ADDRESS_SUFFIXES[a.code]}`, coords: a.coordinates })
 );
 
-interface BatchRouteResult {
-  pickupLabel: string;
-  airportLabel: string;
+interface BatchRoutePlan {
+  originLabel: string;
+  originAddress: string;
+  originCoords: { lat: number; lng: number };
+  destinationLabel: string;
+  destinationAddress: string;
+  destinationCoords: { lat: number; lng: number };
+}
+
+// Every outbound (town -> airport) combination, plus one return (airport -> home) leg per airport.
+// The return legs matter: the airport-return-multiplier only applies when the AIRPORT is the
+// pickup (see test-quote/route.ts's isAirportPickup && !isAirportDropoff check) — without them,
+// this tool could never actually show what changing that multiplier does to a real fare.
+function buildBatchRoutePlans(): BatchRoutePlan[] {
+  const plans: BatchRoutePlan[] = [];
+  for (const pickup of COMMON_PICKUPS) {
+    for (const airport of COMMON_AIRPORTS) {
+      plans.push({
+        originLabel: pickup.label,
+        originAddress: pickup.address,
+        originCoords: pickup.coords,
+        destinationLabel: airport.label,
+        destinationAddress: airport.address,
+        destinationCoords: airport.coords,
+      });
+    }
+  }
+  const homeBase = COMMON_PICKUPS[0];
+  for (const airport of COMMON_AIRPORTS) {
+    plans.push({
+      originLabel: airport.label,
+      originAddress: airport.address,
+      originCoords: airport.coords,
+      destinationLabel: homeBase.label,
+      destinationAddress: homeBase.address,
+      destinationCoords: homeBase.coords,
+    });
+  }
+  return plans;
+}
+
+const BATCH_ROUTE_PLANS: BatchRoutePlan[] = buildBatchRoutePlans();
+
+interface BatchRouteResult extends BatchRoutePlan {
   fareType: 'personal' | 'business';
   status: 'pending' | 'done' | 'error';
   result?: TestQuoteResult;
   error?: string;
 }
 
+function patchBatchRow(rows: BatchRouteResult[], index: number, patch: Partial<BatchRouteResult>): BatchRouteResult[] {
+  return rows.map((r, i) => (i === index ? { ...r, ...patch } : r));
+}
+
 // How many test-quote requests (each a real Google Distance Matrix call) run at once — a full
-// batch is 24 routes; capping concurrency avoids bursting the Maps API all at once.
+// batch is BATCH_ROUTE_PLANS.length routes; capping concurrency avoids bursting the Maps API all
+// at once.
 const BATCH_CONCURRENCY = 6;
 
 export default function AdminPricingPageClient() {
@@ -121,6 +160,8 @@ export default function AdminPricingPageClient() {
   const [batchFareType, setBatchFareType] = useState<'personal' | 'business'>('personal');
   const [batchRows, setBatchRows] = useState<BatchRouteResult[] | null>(null);
   const [batchRunning, setBatchRunning] = useState(false);
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
 
   useEffect(() => {
     authFetch('/api/admin/pricing')
@@ -203,13 +244,11 @@ export default function AdminPricingPageClient() {
   };
 
   const runBatchTest = async () => {
+    if (batchRunning) return; // guards against a double-click firing two overlapping runs
     setBatchRunning(true);
-    const rows: BatchRouteResult[] = [];
-    for (const pickup of COMMON_PICKUPS) {
-      for (const airport of COMMON_AIRPORTS) {
-        rows.push({ pickupLabel: pickup.label, airportLabel: airport.label, fareType: batchFareType, status: 'pending' });
-      }
-    }
+
+    const activeFareType = batchFareType;
+    const rows: BatchRouteResult[] = BATCH_ROUTE_PLANS.map((plan) => ({ ...plan, fareType: activeFareType, status: 'pending' }));
     setBatchRows(rows);
 
     const pricingOverrides = {
@@ -221,23 +260,27 @@ export default function AdminPricingPageClient() {
       minimumFare: form.minimumFare,
     };
 
+    const applyPatch = (index: number, patch: Partial<BatchRouteResult>) => {
+      if (!isMountedRef.current) return;
+      setBatchRows((prev) => (prev ? patchBatchRow(prev, index, patch) : prev));
+    };
+
     let nextIndex = 0;
     const runNext = async (): Promise<void> => {
       const index = nextIndex++;
       if (index >= rows.length) return;
-      const pickup = COMMON_PICKUPS[Math.floor(index / COMMON_AIRPORTS.length)];
-      const airport = COMMON_AIRPORTS[index % COMMON_AIRPORTS.length];
+      const row = rows[index];
 
       try {
         const res = await authFetch('/api/admin/pricing/test-quote', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            origin: pickup.address,
-            destination: airport.address,
-            pickupCoords: pickup.coords,
-            dropoffCoords: airport.coords,
-            fareType: batchFareType,
+            origin: row.originAddress,
+            destination: row.destinationAddress,
+            pickupCoords: row.originCoords,
+            dropoffCoords: row.destinationCoords,
+            fareType: activeFareType,
             pricingOverrides,
           }),
         });
@@ -246,20 +289,19 @@ export default function AdminPricingPageClient() {
           throw new Error(e.error || `Request failed (${res.status})`);
         }
         const data: TestQuoteResult = await res.json();
-        setBatchRows((prev) =>
-          prev ? prev.map((r, i) => (i === index ? { ...r, status: 'done', result: data } : r)) : prev
-        );
+        applyPatch(index, { status: 'done', result: data });
       } catch (e: any) {
-        setBatchRows((prev) =>
-          prev ? prev.map((r, i) => (i === index ? { ...r, status: 'error', error: e.message ?? 'Failed' } : r)) : prev
-        );
+        applyPatch(index, { status: 'error', error: e.message ?? 'Failed' });
       }
 
       await runNext();
     };
 
-    await Promise.all(Array.from({ length: Math.min(BATCH_CONCURRENCY, rows.length) }, () => runNext()));
-    setBatchRunning(false);
+    try {
+      await Promise.all(Array.from({ length: Math.min(BATCH_CONCURRENCY, rows.length) }, () => runNext()));
+    } finally {
+      if (isMountedRef.current) setBatchRunning(false);
+    }
   };
 
   const updateField = (field: keyof PricingForm, value: number) => {
@@ -503,25 +545,27 @@ export default function AdminPricingPageClient() {
             <div>
               <H2>Test common routes</H2>
               <Text size="sm" color="secondary">
-                Runs {COMMON_PICKUPS.length * COMMON_AIRPORTS.length} real routes ({COMMON_PICKUPS.map((p) => p.label).join(', ')} × {COMMON_AIRPORTS.map((a) => a.label).join(', ')}) against the rates above (even if unsaved) — change a rate, run it again, and see every route's fare shift before saving.
+                Runs {BATCH_ROUTE_PLANS.length} real routes — {COMMON_PICKUPS.map((p) => p.label).join(', ')} to each of {COMMON_AIRPORTS.map((a) => a.label).join(', ')}, plus a return leg from each airport back to {COMMON_PICKUPS[0].label} — against the rates above (even if unsaved). Change a rate, run it again, and see every route's fare shift before saving.
               </Text>
             </div>
             <Stack spacing="md" direction="horizontal" style={{ alignItems: 'center' }}>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: batchRunning ? 'not-allowed' : 'pointer' }}>
                 <input
                   type="radio"
                   name="batchFareType"
                   checked={batchFareType === 'personal'}
                   onChange={() => setBatchFareType('personal')}
+                  disabled={batchRunning}
                 />
                 <Text as="span">Personal</Text>
               </label>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: batchRunning ? 'not-allowed' : 'pointer' }}>
                 <input
                   type="radio"
                   name="batchFareType"
                   checked={batchFareType === 'business'}
                   onChange={() => setBatchFareType('business')}
+                  disabled={batchRunning}
                 />
                 <Text as="span">Business</Text>
               </label>
@@ -544,8 +588,8 @@ export default function AdminPricingPageClient() {
                 <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
                   <thead>
                     <tr style={{ textAlign: 'left', borderBottom: '2px solid #e5e5e5' }}>
-                      <th style={{ padding: '6px 8px' }}>Pickup</th>
-                      <th style={{ padding: '6px 8px' }}>Airport</th>
+                      <th style={{ padding: '6px 8px' }}>Origin</th>
+                      <th style={{ padding: '6px 8px' }}>Destination</th>
                       <th style={{ padding: '6px 8px', textAlign: 'right' }}>Miles</th>
                       <th style={{ padding: '6px 8px', textAlign: 'right' }}>Min</th>
                       <th style={{ padding: '6px 8px', textAlign: 'right' }}>Fare</th>
@@ -555,8 +599,8 @@ export default function AdminPricingPageClient() {
                   <tbody>
                     {batchRows.map((row, i) => (
                       <tr key={i} style={{ borderBottom: '1px solid #f0f0f0' }}>
-                        <td style={{ padding: '6px 8px' }}>{row.pickupLabel}</td>
-                        <td style={{ padding: '6px 8px' }}>{row.airportLabel}</td>
+                        <td style={{ padding: '6px 8px' }}>{row.originLabel}</td>
+                        <td style={{ padding: '6px 8px' }}>{row.destinationLabel}</td>
                         {row.status === 'pending' && (
                           <td colSpan={4} style={{ padding: '6px 8px', color: '#999' }}>Calculating…</td>
                         )}

--- a/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
+++ b/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
@@ -47,6 +47,51 @@ const DEFAULT_FORM: PricingForm = {
   minimumFare: 100,
 };
 
+interface CommonPickup {
+  label: string;
+  address: string;
+  coords: { lat: number; lng: number };
+}
+
+interface CommonAirport {
+  label: string;
+  address: string;
+  coords: { lat: number; lng: number };
+}
+
+// The pickup points and airports Gregg's customers actually book most often — real addresses so
+// each one resolves cleanly through Google's Distance Matrix, and real coordinates (matching the
+// service-area/airport-detection logic's own reference points where they overlap) so every route
+// classifies as a normal in-service-area trip rather than tripping the soft/hard-block checks.
+const COMMON_PICKUPS: CommonPickup[] = [
+  { label: 'Fairfield (train station)', address: 'Fairfield, CT', coords: { lat: 41.1408, lng: -73.2633 } },
+  { label: 'Westport (downtown)', address: 'Westport, CT', coords: { lat: 41.1415, lng: -73.3579 } },
+  { label: 'Stamford (train station)', address: 'Stamford, CT', coords: { lat: 41.0534, lng: -73.5387 } },
+  { label: 'Trumbull (town center)', address: 'Trumbull, CT', coords: { lat: 41.2429, lng: -73.2007 } },
+];
+
+const COMMON_AIRPORTS: CommonAirport[] = [
+  { label: 'JFK', address: 'John F. Kennedy International Airport, Queens, NY', coords: { lat: 40.6413111, lng: -73.7781391 } },
+  { label: 'LGA', address: 'LaGuardia Airport, Queens, NY 11371', coords: { lat: 40.7769271, lng: -73.8739659 } },
+  { label: 'EWR', address: 'Newark Liberty International Airport, Newark, NJ', coords: { lat: 40.6895314, lng: -74.1744624 } },
+  { label: 'BDL', address: 'Bradley International Airport, Windsor Locks, CT', coords: { lat: 41.938889, lng: -72.683056 } },
+  { label: 'HVN', address: 'Tweed New Haven Airport, New Haven, CT', coords: { lat: 41.263889, lng: -72.886667 } },
+  { label: 'HPN', address: 'Westchester County Airport, White Plains, NY', coords: { lat: 41.067005, lng: -73.707574 } },
+];
+
+interface BatchRouteResult {
+  pickupLabel: string;
+  airportLabel: string;
+  fareType: 'personal' | 'business';
+  status: 'pending' | 'done' | 'error';
+  result?: TestQuoteResult;
+  error?: string;
+}
+
+// How many test-quote requests (each a real Google Distance Matrix call) run at once — a full
+// batch is 24 routes; capping concurrency avoids bursting the Maps API all at once.
+const BATCH_CONCURRENCY = 6;
+
 export default function AdminPricingPageClient() {
   const [form, setForm] = useState<PricingForm>(DEFAULT_FORM);
   const [loading, setLoading] = useState(true);
@@ -63,6 +108,11 @@ export default function AdminPricingPageClient() {
   const [testLoading, setTestLoading] = useState(false);
   const [testError, setTestError] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<TestQuoteResult | null>(null);
+
+  // Batch route tester state
+  const [batchFareType, setBatchFareType] = useState<'personal' | 'business'>('personal');
+  const [batchRows, setBatchRows] = useState<BatchRouteResult[] | null>(null);
+  const [batchRunning, setBatchRunning] = useState(false);
 
   useEffect(() => {
     authFetch('/api/admin/pricing')
@@ -142,6 +192,66 @@ export default function AdminPricingPageClient() {
       .then((data: TestQuoteResult) => setTestResult(data))
       .catch((e) => setTestError(e.message ?? 'Failed to get test quote'))
       .finally(() => setTestLoading(false));
+  };
+
+  const runBatchTest = async () => {
+    setBatchRunning(true);
+    const rows: BatchRouteResult[] = [];
+    for (const pickup of COMMON_PICKUPS) {
+      for (const airport of COMMON_AIRPORTS) {
+        rows.push({ pickupLabel: pickup.label, airportLabel: airport.label, fareType: batchFareType, status: 'pending' });
+      }
+    }
+    setBatchRows(rows);
+
+    const pricingOverrides = {
+      baseFare: form.baseFare,
+      perMile: form.perMile,
+      perMinute: form.perMinute,
+      airportReturnMultiplier: form.airportReturnMultiplier,
+      personalDiscountPercent: form.personalDiscountPercent,
+      minimumFare: form.minimumFare,
+    };
+
+    let nextIndex = 0;
+    const runNext = async (): Promise<void> => {
+      const index = nextIndex++;
+      if (index >= rows.length) return;
+      const pickup = COMMON_PICKUPS[Math.floor(index / COMMON_AIRPORTS.length)];
+      const airport = COMMON_AIRPORTS[index % COMMON_AIRPORTS.length];
+
+      try {
+        const res = await authFetch('/api/admin/pricing/test-quote', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            origin: pickup.address,
+            destination: airport.address,
+            pickupCoords: pickup.coords,
+            dropoffCoords: airport.coords,
+            fareType: batchFareType,
+            pricingOverrides,
+          }),
+        });
+        if (!res.ok) {
+          const e = await res.json().catch(() => ({}));
+          throw new Error(e.error || `Request failed (${res.status})`);
+        }
+        const data: TestQuoteResult = await res.json();
+        setBatchRows((prev) =>
+          prev ? prev.map((r, i) => (i === index ? { ...r, status: 'done', result: data } : r)) : prev
+        );
+      } catch (e: any) {
+        setBatchRows((prev) =>
+          prev ? prev.map((r, i) => (i === index ? { ...r, status: 'error', error: e.message ?? 'Failed' } : r)) : prev
+        );
+      }
+
+      await runNext();
+    };
+
+    await Promise.all(Array.from({ length: Math.min(BATCH_CONCURRENCY, rows.length) }, () => runNext()));
+    setBatchRunning(false);
   };
 
   const updateField = (field: keyof PricingForm, value: number) => {
@@ -375,6 +485,92 @@ export default function AdminPricingPageClient() {
                   </Text>
                 </Stack>
               </Box>
+            )}
+          </Stack>
+        </Box>
+
+        {/* Batch Route Tester */}
+        <Box variant="outlined" padding="lg">
+          <Stack spacing="md">
+            <div>
+              <H2>Test common routes</H2>
+              <Text size="sm" color="secondary">
+                Runs {COMMON_PICKUPS.length * COMMON_AIRPORTS.length} real routes ({COMMON_PICKUPS.map((p) => p.label).join(', ')} × {COMMON_AIRPORTS.map((a) => a.label).join(', ')}) against the rates above (even if unsaved) — change a rate, run it again, and see every route's fare shift before saving.
+              </Text>
+            </div>
+            <Stack spacing="md" direction="horizontal" style={{ alignItems: 'center' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                <input
+                  type="radio"
+                  name="batchFareType"
+                  checked={batchFareType === 'personal'}
+                  onChange={() => setBatchFareType('personal')}
+                />
+                <Text as="span">Personal</Text>
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                <input
+                  type="radio"
+                  name="batchFareType"
+                  checked={batchFareType === 'business'}
+                  onChange={() => setBatchFareType('business')}
+                />
+                <Text as="span">Business</Text>
+              </label>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={runBatchTest}
+                disabled={batchRunning}
+                text={batchRunning ? 'Running…' : 'Run all routes'}
+              />
+              {batchRunning && batchRows && (
+                <Text size="sm" color="secondary">
+                  {batchRows.filter((r) => r.status !== 'pending').length} / {batchRows.length}
+                </Text>
+              )}
+            </Stack>
+
+            {batchRows && (
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+                  <thead>
+                    <tr style={{ textAlign: 'left', borderBottom: '2px solid #e5e5e5' }}>
+                      <th style={{ padding: '6px 8px' }}>Pickup</th>
+                      <th style={{ padding: '6px 8px' }}>Airport</th>
+                      <th style={{ padding: '6px 8px', textAlign: 'right' }}>Miles</th>
+                      <th style={{ padding: '6px 8px', textAlign: 'right' }}>Min</th>
+                      <th style={{ padding: '6px 8px', textAlign: 'right' }}>Fare</th>
+                      <th style={{ padding: '6px 8px' }}>Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {batchRows.map((row, i) => (
+                      <tr key={i} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                        <td style={{ padding: '6px 8px' }}>{row.pickupLabel}</td>
+                        <td style={{ padding: '6px 8px' }}>{row.airportLabel}</td>
+                        {row.status === 'pending' && (
+                          <td colSpan={4} style={{ padding: '6px 8px', color: '#999' }}>Calculating…</td>
+                        )}
+                        {row.status === 'error' && (
+                          <td colSpan={4} style={{ padding: '6px 8px', color: '#dc2626' }}>{row.error}</td>
+                        )}
+                        {row.status === 'done' && row.result && (
+                          <>
+                            <td style={{ padding: '6px 8px', textAlign: 'right', fontFamily: 'monospace' }}>{row.result.distanceMiles}</td>
+                            <td style={{ padding: '6px 8px', textAlign: 'right', fontFamily: 'monospace' }}>{row.result.durationTrafficMinutes}</td>
+                            <td style={{ padding: '6px 8px', textAlign: 'right', fontFamily: 'monospace', fontWeight: 600 }}>${row.result.fare}</td>
+                            <td style={{ padding: '6px 8px', color: '#d97706' }}>
+                              {row.result.breakdown.minimumFareApplied && 'floor applied'}
+                              {row.result.breakdown.returnMultiplier != null && ' return multiplier'}
+                            </td>
+                          </>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             )}
           </Stack>
         </Box>

--- a/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
+++ b/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
@@ -5,6 +5,7 @@ import { Container, Stack, Text, Box, Button, Input, Label, LoadingSpinner, Aler
 import { LocationInput } from '@/design/components/base-components/forms/LocationInput';
 import { authFetch } from '@/lib/utils/auth-fetch';
 import { formatDateTimeNoSeconds } from '@/utils/formatting';
+import { KNOWN_AIRPORTS } from '@/utils/constants';
 
 interface PricingForm {
   baseFare: number;
@@ -59,25 +60,32 @@ interface CommonAirport {
   coords: { lat: number; lng: number };
 }
 
-// The pickup points and airports Gregg's customers actually book most often — real addresses so
-// each one resolves cleanly through Google's Distance Matrix, and real coordinates (matching the
-// service-area/airport-detection logic's own reference points where they overlap) so every route
-// classifies as a normal in-service-area trip rather than tripping the soft/hard-block checks.
+// The pickup points Gregg's customers actually book most often. Label and address intentionally
+// match (both plain town names) — Google resolves these to the town centroid, so a label implying
+// a specific landmark (e.g. "train station") would overstate precision the query doesn't have.
 const COMMON_PICKUPS: CommonPickup[] = [
-  { label: 'Fairfield (train station)', address: 'Fairfield, CT', coords: { lat: 41.1408, lng: -73.2633 } },
-  { label: 'Westport (downtown)', address: 'Westport, CT', coords: { lat: 41.1415, lng: -73.3579 } },
-  { label: 'Stamford (train station)', address: 'Stamford, CT', coords: { lat: 41.0534, lng: -73.5387 } },
-  { label: 'Trumbull (town center)', address: 'Trumbull, CT', coords: { lat: 41.2429, lng: -73.2007 } },
+  { label: 'Fairfield, CT', address: 'Fairfield, CT', coords: { lat: 41.1408, lng: -73.2633 } },
+  { label: 'Westport, CT', address: 'Westport, CT', coords: { lat: 41.1415, lng: -73.3579 } },
+  { label: 'Stamford, CT', address: 'Stamford, CT', coords: { lat: 41.0534, lng: -73.5387 } },
+  { label: 'Trumbull, CT', address: 'Trumbull, CT', coords: { lat: 41.2429, lng: -73.2007 } },
 ];
 
-const COMMON_AIRPORTS: CommonAirport[] = [
-  { label: 'JFK', address: 'John F. Kennedy International Airport, Queens, NY', coords: { lat: 40.6413111, lng: -73.7781391 } },
-  { label: 'LGA', address: 'LaGuardia Airport, Queens, NY 11371', coords: { lat: 40.7769271, lng: -73.8739659 } },
-  { label: 'EWR', address: 'Newark Liberty International Airport, Newark, NJ', coords: { lat: 40.6895314, lng: -74.1744624 } },
-  { label: 'BDL', address: 'Bradley International Airport, Windsor Locks, CT', coords: { lat: 41.938889, lng: -72.683056 } },
-  { label: 'HVN', address: 'Tweed New Haven Airport, New Haven, CT', coords: { lat: 41.263889, lng: -72.886667 } },
-  { label: 'HPN', address: 'Westchester County Airport, White Plains, NY', coords: { lat: 41.067005, lng: -73.707574 } },
-];
+// A curated, geocodable full address per airport (KNOWN_AIRPORTS' bare `name` is enough for some
+// of these, but a city/state suffix makes the Distance Matrix lookup more reliable) — coordinates
+// are derived from KNOWN_AIRPORTS itself (single source of truth) rather than re-typed here, so
+// this can't silently drift if an airport's reference coordinates are ever tuned in constants.ts.
+const COMMON_AIRPORT_ADDRESSES: Record<string, string> = {
+  JFK: 'John F. Kennedy International Airport, Queens, NY',
+  LGA: 'LaGuardia Airport, Queens, NY 11371',
+  EWR: 'Newark Liberty International Airport, Newark, NJ',
+  BDL: 'Bradley International Airport, Windsor Locks, CT',
+  HVN: 'Tweed New Haven Airport, New Haven, CT',
+  HPN: 'Westchester County Airport, White Plains, NY',
+};
+
+const COMMON_AIRPORTS: CommonAirport[] = KNOWN_AIRPORTS.filter((a) => a.code in COMMON_AIRPORT_ADDRESSES).map(
+  (a) => ({ label: a.code, address: COMMON_AIRPORT_ADDRESSES[a.code], coords: a.coordinates })
+);
 
 interface BatchRouteResult {
   pickupLabel: string;

--- a/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
+++ b/src/app/(admin)/admin/pricing/AdminPricingPageClient.tsx
@@ -161,7 +161,15 @@ export default function AdminPricingPageClient() {
   const [batchRows, setBatchRows] = useState<BatchRouteResult[] | null>(null);
   const [batchRunning, setBatchRunning] = useState(false);
   const isMountedRef = useRef(true);
-  useEffect(() => () => { isMountedRef.current = false; }, []);
+  useEffect(() => {
+    // StrictMode (on by default in this app's dev builds) mounts every component twice: the
+    // first mount's cleanup runs immediately, then the effect setup runs again for the "real"
+    // mount. Without resetting the ref back to true here, that first cleanup would permanently
+    // leave isMountedRef false — every applyPatch and the final setBatchRunning(false) would
+    // silently no-op forever, well before the component actually unmounts.
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
 
   useEffect(() => {
     authFetch('/api/admin/pricing')

--- a/tests/unit/admin-pricing-batch-tester.test.tsx
+++ b/tests/unit/admin-pricing-batch-tester.test.tsx
@@ -34,6 +34,9 @@ const SAVED_PRICING = {
   version: 1,
 };
 
+// 4 pickups x 6 airports (outbound) + 6 airports x 1 home base (return) = 30.
+const TOTAL_BATCH_ROUTES = 30;
+
 function makeTestQuoteResult(overrides: Partial<any> = {}) {
   return {
     fare: 66,
@@ -58,6 +61,12 @@ function makeTestQuoteResult(overrides: Partial<any> = {}) {
   };
 }
 
+function getTestQuoteCalls() {
+  return mockAuthFetch.mock.calls.filter(
+    (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
+  );
+}
+
 describe('AdminPricingPageClient — batch route tester', () => {
   beforeEach(() => {
     mockAuthFetch.mockReset();
@@ -69,7 +78,7 @@ describe('AdminPricingPageClient — batch route tester', () => {
     });
   });
 
-  it('runs all 24 common routes (4 pickups x 6 airports) and renders a result row for each', async () => {
+  it('runs every outbound (pickup x airport) route plus a return leg per airport, rendering a result row for each', async () => {
     render(<AdminPricingPageClient />);
 
     await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
@@ -77,13 +86,11 @@ describe('AdminPricingPageClient — batch route tester', () => {
     fireEvent.click(screen.getByText('Run all routes'));
 
     await waitFor(() => {
-      const testQuoteCalls = mockAuthFetch.mock.calls.filter(
-        (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
-      );
-      expect(testQuoteCalls).toHaveLength(24);
+      expect(getTestQuoteCalls()).toHaveLength(TOTAL_BATCH_ROUTES);
     });
 
-    // Every pickup/airport pair should appear in the rendered table.
+    // Every pickup/airport label should appear (as origin for outbound rows, or as origin for the
+    // return row in the airport's case / destination for the home base in the return row's case).
     await waitFor(() => {
       expect(screen.getAllByText('Fairfield, CT').length).toBeGreaterThan(0);
       expect(screen.getAllByText('JFK').length).toBeGreaterThan(0);
@@ -91,10 +98,24 @@ describe('AdminPricingPageClient — batch route tester', () => {
       expect(screen.getAllByText('Trumbull, CT').length).toBeGreaterThan(0);
     });
 
-    // Fares from the (mocked) results should render.
+    // Fares from the (mocked) results should render for every route.
     await waitFor(() => {
-      expect(screen.getAllByText('$66').length).toBe(24);
+      expect(screen.getAllByText('$66').length).toBe(TOTAL_BATCH_ROUTES);
     });
+  });
+
+  it('sends a route with the airport as the origin for the return legs, so the return-multiplier path is actually exercised', async () => {
+    render(<AdminPricingPageClient />);
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Run all routes'));
+
+    await waitFor(() => expect(getTestQuoteCalls()).toHaveLength(TOTAL_BATCH_ROUTES));
+
+    const bodies = getTestQuoteCalls().map((call) => JSON.parse(call[1].body));
+    const returnLegs = bodies.filter((b) => b.origin === 'John F. Kennedy International Airport, Queens, NY');
+    // Exactly one JFK->home return leg; JFK never appears as a destination-side origin otherwise.
+    expect(returnLegs).toHaveLength(1);
+    expect(returnLegs[0].destination).toBe('Fairfield, CT');
   });
 
   it('sends the currently-edited (possibly unsaved) rates as pricingOverrides for every route, not the last-saved config', async () => {
@@ -108,15 +129,10 @@ describe('AdminPricingPageClient — batch route tester', () => {
     fireEvent.click(screen.getByText('Run all routes'));
 
     await waitFor(() => {
-      const testQuoteCalls = mockAuthFetch.mock.calls.filter(
-        (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
-      );
-      expect(testQuoteCalls.length).toBe(24);
+      expect(getTestQuoteCalls().length).toBe(TOTAL_BATCH_ROUTES);
     });
 
-    const firstCallBody = JSON.parse(mockAuthFetch.mock.calls.find(
-      (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
-    )![1].body);
+    const firstCallBody = JSON.parse(getTestQuoteCalls()[0][1].body);
     expect(firstCallBody.pricingOverrides.baseFare).toBe(25);
   });
 
@@ -140,9 +156,43 @@ describe('AdminPricingPageClient — batch route tester', () => {
     await waitFor(() => {
       expect(screen.getByText('Unable to calculate route')).toBeInTheDocument();
     });
-    // The other 23 routes still complete successfully.
+    // The other routes still complete successfully.
     await waitFor(() => {
-      expect(screen.getAllByText('$66').length).toBe(23);
+      expect(screen.getAllByText('$66').length).toBe(TOTAL_BATCH_ROUTES - 1);
     });
+  });
+
+  it('ignores a second click while a run is already in progress (regression: no re-entrancy guard let a double-click fire two overlapping runs, doubling in-flight requests and defeating the concurrency cap)', async () => {
+    let resolveFirst: (() => void) | null = null;
+    mockAuthFetch.mockImplementation((input: string) => {
+      if (typeof input === 'string' && input.includes('/api/admin/pricing/test-quote')) {
+        return new Promise((resolve) => {
+          if (!resolveFirst) resolveFirst = () => resolve(jsonResponse(makeTestQuoteResult()) as any);
+        });
+      }
+      return jsonResponse(SAVED_PRICING);
+    });
+
+    render(<AdminPricingPageClient />);
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+
+    const button = screen.getByText('Run all routes');
+    fireEvent.click(button);
+    fireEvent.click(button); // second click while the first run's requests are still pending
+    fireEvent.click(button); // and a third, for good measure
+
+    await waitFor(() => {
+      // Concurrency cap is 6 — a re-entrant second/third run would push this well past 6.
+      expect(getTestQuoteCalls().length).toBe(6);
+    });
+  });
+
+  it('re-enables the Run all routes button after all requests settle', async () => {
+    render(<AdminPricingPageClient />);
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Run all routes'));
+
+    await waitFor(() => expect(getTestQuoteCalls()).toHaveLength(TOTAL_BATCH_ROUTES));
+    await waitFor(() => expect(screen.getByText('Run all routes')).not.toBeDisabled());
   });
 });

--- a/tests/unit/admin-pricing-batch-tester.test.tsx
+++ b/tests/unit/admin-pricing-batch-tester.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AdminPricingPageClient from '@/app/(admin)/admin/pricing/AdminPricingPageClient';
+
+const mockAuthFetch = vi.fn();
+
+vi.mock('@/lib/utils/auth-fetch', () => ({
+  authFetch: (...args: any[]) => mockAuthFetch(...args),
+}));
+
+vi.mock('@/design/components/base-components/forms/LocationInput', () => ({
+  __esModule: true,
+  LocationInput: ({ value, onChange, placeholder }: any) => (
+    <input data-testid="location-input" value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('@/utils/formatting', () => ({
+  formatDateTimeNoSeconds: (v: string) => v,
+}));
+
+function jsonResponse(body: any, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
+}
+
+const SAVED_PRICING = {
+  baseFare: 15,
+  perMile: 1.8,
+  perMinute: 0.2,
+  airportReturnMultiplier: 1.15,
+  personalDiscountPercent: 10,
+  minimumFare: 100,
+  updatedAt: undefined,
+  version: 1,
+};
+
+function makeTestQuoteResult(overrides: Partial<any> = {}) {
+  return {
+    fare: 66,
+    distanceMiles: 28.2,
+    durationMinutes: 33,
+    durationTrafficMinutes: 33,
+    breakdown: {
+      baseFare: 15,
+      mileageCharge: 50.76,
+      timeCharge: 6.6,
+      subtotalBeforeModifiers: 73,
+      personalDiscount: 7.24,
+      returnMultiplier: null,
+      preMultiplierFare: null,
+      minimumFare: 100,
+      minimumFareApplied: false,
+    },
+    isAirportPickup: false,
+    isAirportDropoff: true,
+    fareType: 'personal',
+    ...overrides,
+  };
+}
+
+describe('AdminPricingPageClient — batch route tester', () => {
+  beforeEach(() => {
+    mockAuthFetch.mockReset();
+    mockAuthFetch.mockImplementation((input: string) => {
+      if (typeof input === 'string' && input.includes('/api/admin/pricing/test-quote')) {
+        return jsonResponse(makeTestQuoteResult());
+      }
+      return jsonResponse(SAVED_PRICING);
+    });
+  });
+
+  it('runs all 24 common routes (4 pickups x 6 airports) and renders a result row for each', async () => {
+    render(<AdminPricingPageClient />);
+
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Run all routes'));
+
+    await waitFor(() => {
+      const testQuoteCalls = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
+      );
+      expect(testQuoteCalls).toHaveLength(24);
+    });
+
+    // Every pickup/airport pair should appear in the rendered table.
+    await waitFor(() => {
+      expect(screen.getAllByText('Fairfield (train station)').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('JFK').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('HPN').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Trumbull (town center)').length).toBeGreaterThan(0);
+    });
+
+    // Fares from the (mocked) results should render.
+    await waitFor(() => {
+      expect(screen.getAllByText('$66').length).toBe(24);
+    });
+  });
+
+  it('sends the currently-edited (possibly unsaved) rates as pricingOverrides for every route, not the last-saved config', async () => {
+    render(<AdminPricingPageClient />);
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+
+    // baseFare loads as 15 (SAVED_PRICING) — locate its input by that displayed value.
+    const baseFareInput = screen.getByDisplayValue('15') as HTMLInputElement;
+    fireEvent.change(baseFareInput, { target: { value: '25' } });
+
+    fireEvent.click(screen.getByText('Run all routes'));
+
+    await waitFor(() => {
+      const testQuoteCalls = mockAuthFetch.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
+      );
+      expect(testQuoteCalls.length).toBe(24);
+    });
+
+    const firstCallBody = JSON.parse(mockAuthFetch.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('/api/admin/pricing/test-quote')
+    )![1].body);
+    expect(firstCallBody.pricingOverrides.baseFare).toBe(25);
+  });
+
+  it('shows a per-row error without failing the rest of the batch when one route fails', async () => {
+    let callCount = 0;
+    mockAuthFetch.mockImplementation((input: string) => {
+      if (typeof input === 'string' && input.includes('/api/admin/pricing/test-quote')) {
+        callCount++;
+        if (callCount === 1) {
+          return jsonResponse({ error: 'Unable to calculate route' }, false, 400);
+        }
+        return jsonResponse(makeTestQuoteResult());
+      }
+      return jsonResponse(SAVED_PRICING);
+    });
+
+    render(<AdminPricingPageClient />);
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Run all routes'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to calculate route')).toBeInTheDocument();
+    });
+    // The other 23 routes still complete successfully.
+    await waitFor(() => {
+      expect(screen.getAllByText('$66').length).toBe(23);
+    });
+  });
+});

--- a/tests/unit/admin-pricing-batch-tester.test.tsx
+++ b/tests/unit/admin-pricing-batch-tester.test.tsx
@@ -85,10 +85,10 @@ describe('AdminPricingPageClient — batch route tester', () => {
 
     // Every pickup/airport pair should appear in the rendered table.
     await waitFor(() => {
-      expect(screen.getAllByText('Fairfield (train station)').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Fairfield, CT').length).toBeGreaterThan(0);
       expect(screen.getAllByText('JFK').length).toBeGreaterThan(0);
       expect(screen.getAllByText('HPN').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Trumbull (town center)').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Trumbull, CT').length).toBeGreaterThan(0);
     });
 
     // Fares from the (mocked) results should render.

--- a/tests/unit/admin-pricing-batch-tester.test.tsx
+++ b/tests/unit/admin-pricing-batch-tester.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AdminPricingPageClient from '@/app/(admin)/admin/pricing/AdminPricingPageClient';
@@ -185,6 +186,20 @@ describe('AdminPricingPageClient — batch route tester', () => {
       // Concurrency cap is 6 — a re-entrant second/third run would push this well past 6.
       expect(getTestQuoteCalls().length).toBe(6);
     });
+  });
+
+  it('still completes a batch run under React.StrictMode (regression: StrictMode double-invokes effects in dev — mount, cleanup, remount — and the mounted-ref guard was not reset on the second setup, so it stayed permanently false and every row/patch silently no-op\'d after the first render cycle)', async () => {
+    render(
+      <React.StrictMode>
+        <AdminPricingPageClient />
+      </React.StrictMode>
+    );
+    await waitFor(() => expect(screen.getByText('Run all routes')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Run all routes'));
+
+    await waitFor(() => expect(getTestQuoteCalls()).toHaveLength(TOTAL_BATCH_ROUTES));
+    await waitFor(() => expect(screen.getAllByText('$66').length).toBe(TOTAL_BATCH_ROUTES));
+    await waitFor(() => expect(screen.getByText('Run all routes')).not.toBeDisabled());
   });
 
   it('re-enables the Run all routes button after all requests settle', async () => {


### PR DESCRIPTION
## Summary
- Adds a "Test common routes" section to `/admin/pricing`: runs 30 real routes (4 pickup towns × 6 airports, plus a return leg per airport) against the currently-edited rates, so a pricing change can be sanity-checked across a realistic route spread before saving instead of testing one route at a time.
- Airport addresses/coordinates are derived from the existing `KNOWN_AIRPORTS` constant (single source of truth), not re-typed.
- Return legs (airport → home) are included specifically so the airport-return-multiplier can actually be validated by this tool, not just the base/per-mile/per-minute rates.
- Reuses the existing admin-only `/api/admin/pricing/test-quote` endpoint — no new API surface.

This went through both required pre-PR review passes (yp-staff-review + code-review) before opening; all findings from both were fixed and verified — including a re-entrancy guard, unmount-safety, and try/finally around the run-state flag in the concurrency-limited request runner.

## Test plan
- [x] `npm run type-check` clean
- [x] Full unit + integration suite passing (pre-push hook)
- [x] Build passing (pre-push hook)
- [x] New regression tests: `tests/unit/admin-pricing-batch-tester.test.tsx` — full batch run (30 routes), return-leg/return-multiplier coverage, pricingOverrides propagation, per-row error isolation, re-entrancy guard, button re-enables after completion
- [ ] Manual: log into `/admin/pricing`, click "Run all routes," confirm the table populates and a rate change visibly shifts the fares on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)