### PR TITLE
fix: forward every inbound SMS to Gregg's phone, not just the first unread

### DIFF
--- a/docs/plans/2026-03-06-sms-inbox-design.md
+++ b/docs/plans/2026-03-06-sms-inbox-design.md
@@ -51,6 +51,7 @@ interface SmsThread {
   unreadCount: number;           // incremented on inbound, reset on Gregg opening thread
   lastInboundAt?: Timestamp;
   lastOutboundAt?: Timestamp;
+  lastAdminNotifiedAt?: Timestamp; // last time a forward SMS was sent to Gregg's phone
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
@@ -86,7 +87,7 @@ Old messages without `threadId` remain as historical flat log. No migration need
 2. Find `smsThread` by `customerPhone` or create one
 3. Save message to `smsMessages` with `threadId`, `senderType: 'customer'`
 4. Update thread metadata (`lastMessageAt`, `lastMessagePreview`, `unreadCount += 1`)
-5. Send notification SMS to Gregg: `"New message from [phone]: '[preview]' Reply: [domain]/admin/messages/[threadId]"`
+5. Send notification SMS to Gregg unless one was already sent for this thread within the last 60s (`lastAdminNotifiedAt` cooldown — independent of `unreadCount`/dashboard read state, so a thread Gregg never opens in the web dashboard keeps forwarding): `"New message from [phone]: '[preview]' Reply: [domain]/admin/messages/[threadId]"`
 6. Return TwiML `<Response></Response>`
 
 ### Reply endpoint
@@ -147,7 +148,7 @@ One-time login on his phone. Link from notification SMS lands directly on the th
 
 ## Notification SMS
 
-Sent to `GREGG_SMS_FORWARD_NUMBER` (existing env var) on every inbound customer message:
+Sent to `GREGG_SMS_FORWARD_NUMBER` (existing env var) on inbound customer messages, throttled to at most one per thread per 60s (`lastAdminNotifiedAt`) — this is independent of the dashboard's `unreadCount`/read state, so threads Gregg never opens in the web dashboard still keep forwarding:
 
 ```
 New message from (203) 555-1234: "Hey, can you pick me up at..."

--- a/src/app/api/twilio/incoming-sms/route.ts
+++ b/src/app/api/twilio/incoming-sms/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import twilio from 'twilio';
 import { sendSms } from '@/lib/services/twilio-service';
 import { saveSmsMessage } from '@/lib/services/sms-message-service';
-import { findOrCreateThread, updateThreadOnInbound } from '@/lib/services/sms-thread-service';
+import { findOrCreateThread, updateThreadOnInbound, recordAdminNotified } from '@/lib/services/sms-thread-service';
 
 const authToken = process.env.TWILIO_AUTH_TOKEN;
 const forwardToNumber = process.env.GREGG_SMS_FORWARD_NUMBER || process.env.ADMIN_FORWARD_SMS_TO;
@@ -71,6 +71,9 @@ export async function POST(request: NextRequest) {
         threadId ? `${baseUrl}/admin/messages/${threadId}` : `${baseUrl}/admin/messages`
       }`;
       await sendSms({ to: forwardToNumber, body: forwardBody, logMessage: false });
+      if (threadId) {
+        await recordAdminNotified(threadId);
+      }
     } catch (err) {
       console.error('[Twilio webhook] Failed to forward to Gregg:', err);
     }

--- a/src/lib/services/sms-thread-service.ts
+++ b/src/lib/services/sms-thread-service.ts
@@ -118,20 +118,24 @@ export async function updateThreadOnInbound(threadId: string, messageBody: strin
       : 0;
   const shouldNotifyAdmin = Date.now() - lastNotifiedMs > ADMIN_NOTIFY_COOLDOWN_MS;
 
-  const update: Record<string, unknown> = {
+  await threadRef.update({
     lastMessageAt: FieldValue.serverTimestamp(),
     lastMessagePreview: toPreview(messageBody),
     lastInboundAt: FieldValue.serverTimestamp(),
     unreadCount: FieldValue.increment(1),
     updatedAt: FieldValue.serverTimestamp(),
-  };
-  if (shouldNotifyAdmin) {
-    update.lastAdminNotifiedAt = FieldValue.serverTimestamp();
-  }
-
-  await threadRef.update(update);
+  });
 
   return shouldNotifyAdmin;
+}
+
+// Call only after the forward SMS to Gregg's phone has actually been sent —
+// recording this on a failed send would suppress the next message's retry for no reason.
+export async function recordAdminNotified(threadId: string): Promise<void> {
+  const db = getAdminDb();
+  await db.collection(THREADS_COLLECTION).doc(threadId).update({
+    lastAdminNotifiedAt: FieldValue.serverTimestamp(),
+  });
 }
 
 export async function updateThreadOnOutbound(threadId: string, messageBody: string): Promise<void> {

--- a/src/lib/services/sms-thread-service.ts
+++ b/src/lib/services/sms-thread-service.ts
@@ -4,6 +4,10 @@ import { getAdminDb } from '@/lib/utils/firebase-admin';
 const THREADS_COLLECTION = 'smsThreads';
 const MESSAGES_COLLECTION = 'smsMessages';
 
+// Forwarding Gregg's phone is independent of the admin dashboard's unread badge —
+// otherwise a thread he never opens in the dashboard stops forwarding after its first message.
+const ADMIN_NOTIFY_COOLDOWN_MS = 60_000;
+
 export interface SmsThread {
   id: string;
   customerPhone: string;
@@ -105,18 +109,29 @@ export async function findOrCreateThread(
 
 export async function updateThreadOnInbound(threadId: string, messageBody: string): Promise<boolean> {
   const db = getAdminDb();
-  const threadDoc = await db.collection(THREADS_COLLECTION).doc(threadId).get();
-  const currentUnreadCount = Number(threadDoc.data()?.unreadCount ?? 0);
+  const threadRef = db.collection(THREADS_COLLECTION).doc(threadId);
+  const threadDoc = await threadRef.get();
+  const lastAdminNotifiedAt = threadDoc.data()?.lastAdminNotifiedAt;
+  const lastNotifiedMs =
+    lastAdminNotifiedAt && typeof lastAdminNotifiedAt.toDate === 'function'
+      ? lastAdminNotifiedAt.toDate().getTime()
+      : 0;
+  const shouldNotifyAdmin = Date.now() - lastNotifiedMs > ADMIN_NOTIFY_COOLDOWN_MS;
 
-  await db.collection(THREADS_COLLECTION).doc(threadId).update({
+  const update: Record<string, unknown> = {
     lastMessageAt: FieldValue.serverTimestamp(),
     lastMessagePreview: toPreview(messageBody),
     lastInboundAt: FieldValue.serverTimestamp(),
     unreadCount: FieldValue.increment(1),
     updatedAt: FieldValue.serverTimestamp(),
-  });
+  };
+  if (shouldNotifyAdmin) {
+    update.lastAdminNotifiedAt = FieldValue.serverTimestamp();
+  }
 
-  return currentUnreadCount === 0;
+  await threadRef.update(update);
+
+  return shouldNotifyAdmin;
 }
 
 export async function updateThreadOnOutbound(threadId: string, messageBody: string): Promise<void> {

--- a/tests/unit/incoming-sms-threading.test.ts
+++ b/tests/unit/incoming-sms-threading.test.ts
@@ -17,16 +17,18 @@ vi.mock('@/lib/services/sms-message-service', () => ({
 vi.mock('@/lib/services/sms-thread-service', () => ({
   findOrCreateThread: vi.fn().mockResolvedValue({ threadId: 'thread_abc', created: false }),
   updateThreadOnInbound: vi.fn().mockResolvedValue(true),
+  recordAdminNotified: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { sendSms } from '@/lib/services/twilio-service';
 import { saveSmsMessage } from '@/lib/services/sms-message-service';
-import { findOrCreateThread, updateThreadOnInbound } from '@/lib/services/sms-thread-service';
+import { findOrCreateThread, updateThreadOnInbound, recordAdminNotified } from '@/lib/services/sms-thread-service';
 
 const mockSendSms = sendSms as unknown as ReturnType<typeof vi.fn>;
 const mockSaveSmsMessage = saveSmsMessage as unknown as ReturnType<typeof vi.fn>;
 const mockFindOrCreateThread = findOrCreateThread as unknown as ReturnType<typeof vi.fn>;
 const mockUpdateThreadOnInbound = updateThreadOnInbound as unknown as ReturnType<typeof vi.fn>;
+const mockRecordAdminNotified = recordAdminNotified as unknown as ReturnType<typeof vi.fn>;
 
 let POST: typeof import('@/app/api/twilio/incoming-sms/route').POST;
 
@@ -75,6 +77,31 @@ describe('POST /api/twilio/incoming-sms (threading)', () => {
         body: expect.stringContaining('/admin/messages/thread_abc'),
       })
     );
+    expect(mockRecordAdminNotified).toHaveBeenCalledWith('thread_abc');
+  });
+
+  it('does not record the notification when the forward SMS to Gregg fails', async () => {
+    mockSendSms.mockRejectedValueOnce(new Error('Twilio API error'));
+
+    const response = await POST(
+      new Request('https://www.fairfieldairportcar.com/api/twilio/incoming-sms', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'x-twilio-signature': 'valid-signature',
+        },
+        body: new URLSearchParams({
+          From: '+12035550123',
+          To: '+16462216370',
+          Body: 'Are you there?',
+          MessageSid: 'SM125',
+        }).toString(),
+      }) as any
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSendSms).toHaveBeenCalled();
+    expect(mockRecordAdminNotified).not.toHaveBeenCalled();
   });
 
   it('does not notify Gregg again when the thread already has unread messages', async () => {
@@ -104,5 +131,6 @@ describe('POST /api/twilio/incoming-sms (threading)', () => {
       })
     );
     expect(mockSendSms).not.toHaveBeenCalled();
+    expect(mockRecordAdminNotified).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/sms-thread-service.test.ts
+++ b/tests/unit/sms-thread-service.test.ts
@@ -121,7 +121,7 @@ describe('sms-thread-service', () => {
     );
   });
 
-  it('updates inbound thread metadata, increments unread count, and notifies admin when never notified before', async () => {
+  it('updates inbound thread metadata, increments unread count, and reports notify-worthy when never notified before', async () => {
     threadDocGet.mockResolvedValue({
       exists: true,
       data: () => ({ unreadCount: 0 }),
@@ -134,8 +134,12 @@ describe('sms-thread-service', () => {
       expect.objectContaining({
         lastMessagePreview: 'Can you pick me up at JFK tomorrow?',
         unreadCount: { __type: 'increment', amount: 1 },
-        lastAdminNotifiedAt: { __type: 'serverTimestamp' },
       })
+    );
+    // lastAdminNotifiedAt is recorded separately via recordAdminNotified, only after a
+    // successful forward — never written here, so a failed send can't suppress a retry.
+    expect(threadDocUpdate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ lastAdminNotifiedAt: expect.anything() })
     );
     expect(shouldNotifyAdmin).toBe(true);
   });
@@ -183,6 +187,15 @@ describe('sms-thread-service', () => {
     const shouldNotifyAdmin = await updateThreadOnInbound('thread_123', 'Still there?');
 
     expect(shouldNotifyAdmin).toBe(true);
+  });
+
+  it('records the admin-notified timestamp when called directly', async () => {
+    const { recordAdminNotified } = await import('@/lib/services/sms-thread-service');
+    await recordAdminNotified('thread_123');
+
+    expect(threadDocUpdate).toHaveBeenCalledWith({
+      lastAdminNotifiedAt: { __type: 'serverTimestamp' },
+    });
   });
 
   it('marks a thread read by resetting unread count', async () => {

--- a/tests/unit/sms-thread-service.test.ts
+++ b/tests/unit/sms-thread-service.test.ts
@@ -121,7 +121,7 @@ describe('sms-thread-service', () => {
     );
   });
 
-  it('updates inbound thread metadata, increments unread count, and returns true for first unread message', async () => {
+  it('updates inbound thread metadata, increments unread count, and notifies admin when never notified before', async () => {
     threadDocGet.mockResolvedValue({
       exists: true,
       data: () => ({ unreadCount: 0 }),
@@ -134,21 +134,55 @@ describe('sms-thread-service', () => {
       expect.objectContaining({
         lastMessagePreview: 'Can you pick me up at JFK tomorrow?',
         unreadCount: { __type: 'increment', amount: 1 },
+        lastAdminNotifiedAt: { __type: 'serverTimestamp' },
       })
     );
     expect(shouldNotifyAdmin).toBe(true);
   });
 
-  it('suppresses repeated admin notifications when thread already has unread messages', async () => {
+  it('still notifies admin on a second unread message, since forwarding no longer depends on unread count', async () => {
     threadDocGet.mockResolvedValue({
       exists: true,
-      data: () => ({ unreadCount: 2 }),
+      data: () => ({ unreadCount: 2, lastAdminNotifiedAt: null }),
     });
 
     const { updateThreadOnInbound } = await import('@/lib/services/sms-thread-service');
     const shouldNotifyAdmin = await updateThreadOnInbound('thread_123', 'Following up on my last message');
 
+    expect(shouldNotifyAdmin).toBe(true);
+  });
+
+  it('suppresses admin notification when one was already sent within the cooldown window', async () => {
+    threadDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        unreadCount: 2,
+        lastAdminNotifiedAt: { toDate: () => new Date(Date.now() - 5_000) },
+      }),
+    });
+
+    const { updateThreadOnInbound } = await import('@/lib/services/sms-thread-service');
+    const shouldNotifyAdmin = await updateThreadOnInbound('thread_123', 'Following up again');
+
+    expect(threadDocUpdate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ lastAdminNotifiedAt: expect.anything() })
+    );
     expect(shouldNotifyAdmin).toBe(false);
+  });
+
+  it('notifies admin again once the cooldown window has passed', async () => {
+    threadDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        unreadCount: 3,
+        lastAdminNotifiedAt: { toDate: () => new Date(Date.now() - 120_000) },
+      }),
+    });
+
+    const { updateThreadOnInbound } = await import('@/lib/services/sms-thread-service');
+    const shouldNotifyAdmin = await updateThreadOnInbound('thread_123', 'Still there?');
+
+    expect(shouldNotifyAdmin).toBe(true);
   });
 
   it('marks a thread read by resetting unread count', async () => {


### PR DESCRIPTION
## Summary
- `updateThreadOnInbound` previously only forwarded an inbound customer text to Gregg's phone when the thread's `unreadCount` was 0 (i.e. the first unread message). That reset only happens when someone opens the thread in the admin web dashboard — since Gregg works from his phone and rarely opens it, any repeat message in a thread silently stopped forwarding after the first one.
- Forwarding now uses its own `lastAdminNotifiedAt` cooldown (60s) on the thread doc, fully independent of the dashboard's unread badge.
- Updated `docs/plans/2026-03-06-sms-inbox-design.md` to describe the new field/behavior.

## Test plan
- [x] `npx vitest run tests/unit/sms-thread-service.test.ts tests/unit/incoming-sms-threading.test.ts tests/unit/admin-messages-threads.route.test.ts` — 14/14 passing
- [x] `tsc --noEmit` clean on changed files
- [x] pre-push hook (unit + integration + build) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)