### PR TITLE
feat: let Gregg text customers proactively and send mass texts

### DIFF
--- a/src/app/(admin)/admin/bookings/AdminBookingsPageClient.tsx
+++ b/src/app/(admin)/admin/bookings/AdminBookingsPageClient.tsx
@@ -26,6 +26,7 @@ export default function AdminBookingsPageClient() {
         <BookingFilters
           bookings={b.bookings}
           selectedStatus={b.selectedStatus} onStatusChange={b.setSelectedStatus}
+          selectedTimeWindow={b.selectedTimeWindow} onTimeWindowChange={b.setSelectedTimeWindow}
           selectedAirport={b.selectedAirport} onAirportChange={b.setSelectedAirport}
           searchQuery={b.searchQuery} onSearchChange={b.setSearchQuery}
           startDate={b.startDate} onStartDateChange={b.setStartDate}
@@ -34,7 +35,7 @@ export default function AdminBookingsPageClient() {
         <BookingsCount>Showing {b.filteredBookings.length} booking{b.filteredBookings.length !== 1 ? 's' : ''}</BookingsCount>
         <BookingsTable
           bookings={b.filteredBookings}
-          resendingId={b.resendingId} cancellingId={b.cancellingId}
+          resendingId={b.resendingId} cancellingId={b.cancellingId} textingId={b.textingId}
           rejectionModalOpen={b.rejectionModalOpen} bookingToReject={b.bookingToReject}
           rejectionReason={b.rejectionReason} onRejectionReasonChange={b.setRejectionReason}
           rejectionReasonType={b.rejectionReasonType} onRejectionReasonTypeChange={b.setRejectionReasonType}
@@ -42,6 +43,7 @@ export default function AdminBookingsPageClient() {
           onStatusUpdate={b.actions.handleStatusUpdate} onResendConfirmation={b.actions.handleResendConfirmation}
           onCancelBooking={b.actions.handleCancelBooking} onDeleteBooking={b.actions.handleDeleteBooking}
           onApproveException={b.actions.handleApproveException} onOpenRejectionModal={b.actions.openRejectionModal}
+          onTextCustomer={b.actions.handleTextCustomer}
         />
       </PageContainer>
     </Container>

--- a/src/app/(admin)/admin/bookings/BookingFilters.tsx
+++ b/src/app/(admin)/admin/bookings/BookingFilters.tsx
@@ -2,12 +2,24 @@
 
 import { Input } from '@/design/ui';
 import { AIRPORTS, FilterBar, FilterButton } from './bookings-styles';
+import { getPickupDateTime, parseDate } from './bookings-utils';
 import type { Booking } from '@/lib/services/database-service';
+
+const countByTimeWindow = (bookings: Booking[], window: 'upcoming' | 'past'): number => {
+  const now = new Date();
+  return bookings.filter((b) => {
+    const pickup = parseDate(getPickupDateTime(b));
+    if (!pickup) return false;
+    return window === 'upcoming' ? pickup >= now : pickup < now;
+  }).length;
+};
 
 interface BookingFiltersProps {
   bookings: Booking[];
   selectedStatus: string;
   onStatusChange: (status: string) => void;
+  selectedTimeWindow: 'upcoming' | 'past' | 'all';
+  onTimeWindowChange: (window: 'upcoming' | 'past' | 'all') => void;
   selectedAirport: string;
   onAirportChange: (airport: string) => void;
   searchQuery: string;
@@ -22,6 +34,8 @@ export function BookingFilters({
   bookings,
   selectedStatus,
   onStatusChange,
+  selectedTimeWindow,
+  onTimeWindowChange,
   selectedAirport,
   onAirportChange,
   searchQuery,
@@ -32,6 +46,18 @@ export function BookingFilters({
   onEndDateChange,
 }: BookingFiltersProps) {
   return (
+    <>
+    <FilterBar>
+      <FilterButton $active={selectedTimeWindow === 'upcoming'} onClick={() => onTimeWindowChange('upcoming')}>
+        Upcoming ({countByTimeWindow(bookings, 'upcoming')})
+      </FilterButton>
+      <FilterButton $active={selectedTimeWindow === 'past'} onClick={() => onTimeWindowChange('past')}>
+        Past ({countByTimeWindow(bookings, 'past')})
+      </FilterButton>
+      <FilterButton $active={selectedTimeWindow === 'all'} onClick={() => onTimeWindowChange('all')}>
+        All Dates
+      </FilterButton>
+    </FilterBar>
     <FilterBar>
       <FilterButton $active={selectedStatus === 'all'} onClick={() => onStatusChange('all')}>
         All ({bookings.length})
@@ -71,5 +97,6 @@ export function BookingFilters({
       <Input type="date" value={startDate} onChange={(e) => onStartDateChange(e.target.value)} aria-label="Start date" />
       <Input type="date" value={endDate} onChange={(e) => onEndDateChange(e.target.value)} aria-label="End date" />
     </FilterBar>
+    </>
   );
 }

--- a/src/app/(admin)/admin/bookings/BookingsTable.tsx
+++ b/src/app/(admin)/admin/bookings/BookingsTable.tsx
@@ -52,6 +52,7 @@ interface BookingsTableProps {
   bookings: Booking[];
   resendingId: string | null;
   cancellingId: string | null;
+  textingId: string | null;
   rejectionModalOpen: boolean;
   bookingToReject: Booking | null;
   rejectionReason: string;
@@ -66,12 +67,14 @@ interface BookingsTableProps {
   onDeleteBooking: (booking: Booking) => Promise<void>;
   onApproveException: (booking: Booking) => Promise<void>;
   onOpenRejectionModal: (booking: Booking) => void;
+  onTextCustomer: (booking: Booking) => Promise<void>;
 }
 
 export function BookingsTable({
   bookings,
   resendingId,
   cancellingId,
+  textingId,
   rejectionModalOpen,
   bookingToReject,
   rejectionReason,
@@ -86,6 +89,7 @@ export function BookingsTable({
   onDeleteBooking,
   onApproveException,
   onOpenRejectionModal,
+  onTextCustomer,
 }: BookingsTableProps) {
   if (bookings.length === 0) {
     return (
@@ -174,6 +178,15 @@ export function BookingsTable({
                       <Link href={`/booking/${booking.id}`}>
                         <Button size="sm" variant="outline" text="View" />
                       </Link>
+                      {getCustomerPhone(booking) && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => onTextCustomer(booking)}
+                          disabled={textingId === booking.id}
+                          text={textingId === booking.id ? 'Opening…' : '💬 Text'}
+                        />
+                      )}
                       {booking.status !== 'cancelled' && (
                         <Button
                           size="sm"

--- a/src/app/(admin)/admin/bookings/useBookings.ts
+++ b/src/app/(admin)/admin/bookings/useBookings.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   deleteDocument,
   getAllBookings,
@@ -24,12 +25,17 @@ import {
 
 export function useBookings() {
   const { cmsData } = useCMSData();
+  const router = useRouter();
 
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
+  // Defaults to 'upcoming' — Gregg's day-to-day question is "what's coming up," and with no
+  // time-window filter the oldest-pickup-first sort put whatever stale/past booking existed at
+  // the very top of the page instead of his next ride.
+  const [selectedTimeWindow, setSelectedTimeWindow] = useState<'upcoming' | 'past' | 'all'>('upcoming');
   const [selectedAirport, setSelectedAirport] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [startDate, setStartDate] = useState<string>('');
@@ -146,6 +152,36 @@ export function useBookings() {
     } catch (err) {
       console.error('Error deleting booking:', err);
       setError('Failed to delete booking');
+    }
+  };
+
+  const [textingId, setTextingId] = useState<string | null>(null);
+
+  const handleTextCustomer = async (booking: Booking) => {
+    const phone = getCustomerPhone(booking);
+    if (!phone) {
+      setError('This booking has no customer phone number on file.');
+      return;
+    }
+
+    try {
+      setTextingId(booking.id!);
+      setError(null);
+      const res = await authFetch('/api/admin/messages/threads/find-or-create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phone, name: getCustomerName(booking) }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error || 'Could not start conversation');
+      }
+      const data = await res.json();
+      router.push(`/admin/messages/${data.threadId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not start conversation');
+    } finally {
+      setTextingId(null);
     }
   };
 
@@ -282,8 +318,17 @@ export function useBookings() {
       filtered = filtered.filter((b) => getAirportFromBooking(b) === selectedAirport);
     }
 
+    if (selectedTimeWindow !== 'all') {
+      const now = new Date();
+      filtered = filtered.filter((b) => {
+        const pickup = parseDate(getPickupDateTime(b));
+        if (!pickup) return false;
+        return selectedTimeWindow === 'upcoming' ? pickup >= now : pickup < now;
+      });
+    }
+
     return filtered;
-  }, [bookings, selectedStatus, searchQuery, startDate, endDate, selectedAirport]);
+  }, [bookings, selectedStatus, searchQuery, startDate, endDate, selectedAirport, selectedTimeWindow]);
 
   return {
     bookings,
@@ -294,6 +339,8 @@ export function useBookings() {
     stats,
     selectedStatus,
     setSelectedStatus,
+    selectedTimeWindow,
+    setSelectedTimeWindow,
     selectedAirport,
     setSelectedAirport,
     searchQuery,
@@ -304,6 +351,7 @@ export function useBookings() {
     setEndDate,
     resendingId,
     cancellingId,
+    textingId,
     rejectionModalOpen,
     bookingToReject,
     rejectionReason,
@@ -318,6 +366,7 @@ export function useBookings() {
       handleCancelBooking,
       handleDeleteBooking,
       handleApproveException,
+      handleTextCustomer,
       openRejectionModal,
     },
   };

--- a/src/app/(admin)/admin/marketing/sms/AdminSmsMarketingPageClient.tsx
+++ b/src/app/(admin)/admin/marketing/sms/AdminSmsMarketingPageClient.tsx
@@ -170,7 +170,7 @@ export default function AdminSmsMarketingPageClient() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          recipients: finalRecipients.map((r) => ({ phone: r.phone, name: r.name })),
+          recipients: finalRecipients.map((r) => ({ phone: r.phone, name: r.name, optedIn: r.optedIn === true })),
           messageTemplate: messageTemplate.trim(),
         }),
       });

--- a/src/app/(admin)/admin/marketing/sms/AdminSmsMarketingPageClient.tsx
+++ b/src/app/(admin)/admin/marketing/sms/AdminSmsMarketingPageClient.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Alert, Badge, Box, Button, Container, H1, LoadingSpinner, Stack, Text, Textarea } from '@/design/ui';
+import { authFetch } from '@/lib/utils/auth-fetch';
+import { formatDateTimeNoSeconds } from '@/utils/formatting';
+
+interface SmsContact {
+  name: string;
+  phone: string;
+  optedIn: boolean;
+  lastBookingDate: string | null;
+}
+
+interface ManualRecipient {
+  name: string;
+  phone: string;
+}
+
+interface SendResult {
+  total: number;
+  successful: number;
+  failed: number;
+  results: Array<{ phone: string; name: string; success: boolean; error?: string }>;
+}
+
+const ContactRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--color-primary, #2563eb);
+  }
+`;
+
+const ContactList = styled(Box)`
+  max-height: 360px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+// Loose local key for client-side dedup/merge display only — the server independently
+// validates/normalizes every phone number before sending, this just avoids double-counting.
+const dedupeKey = (phone: string): string => phone.replace(/[^\d]/g, '').slice(-10);
+
+const parseManualEntries = (raw: string): ManualRecipient[] => {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const commaIndex = line.lastIndexOf(',');
+      if (commaIndex === -1) return { name: 'there', phone: line.trim() };
+      return {
+        name: line.slice(0, commaIndex).trim() || 'there',
+        phone: line.slice(commaIndex + 1).trim(),
+      };
+    })
+    .filter((r) => r.phone.replace(/[^\d]/g, '').length >= 10);
+};
+
+export default function AdminSmsMarketingPageClient() {
+  const [contacts, setContacts] = useState<SmsContact[]>([]);
+  const [loadingContacts, setLoadingContacts] = useState(true);
+  const [contactsError, setContactsError] = useState<string | null>(null);
+  const [selectedPhones, setSelectedPhones] = useState<Set<string>>(new Set());
+  const [manualEntriesText, setManualEntriesText] = useState('');
+  const [messageTemplate, setMessageTemplate] = useState('');
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [sendResult, setSendResult] = useState<SendResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadContacts() {
+      try {
+        setLoadingContacts(true);
+        setContactsError(null);
+        const res = await authFetch('/api/admin/sms-campaign/contacts');
+        if (!res.ok) throw new Error('Failed to load contacts');
+        const data = await res.json();
+        if (!cancelled) setContacts(data.contacts ?? []);
+      } catch (err) {
+        if (!cancelled) setContactsError(err instanceof Error ? err.message : 'Failed to load contacts');
+      } finally {
+        if (!cancelled) setLoadingContacts(false);
+      }
+    }
+    loadContacts();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const manualRecipients = useMemo(() => parseManualEntries(manualEntriesText), [manualEntriesText]);
+
+  const selectedContacts = useMemo(
+    () => contacts.filter((c) => selectedPhones.has(c.phone)),
+    [contacts, selectedPhones]
+  );
+
+  const finalRecipients = useMemo(() => {
+    const merged = new Map<string, { name: string; phone: string; optedIn: boolean | null }>();
+    for (const c of selectedContacts) {
+      merged.set(dedupeKey(c.phone), { name: c.name, phone: c.phone, optedIn: c.optedIn });
+    }
+    for (const m of manualRecipients) {
+      const key = dedupeKey(m.phone);
+      if (!merged.has(key)) {
+        merged.set(key, { name: m.name, phone: m.phone, optedIn: null });
+      }
+    }
+    return Array.from(merged.values());
+  }, [selectedContacts, manualRecipients]);
+
+  const notOptedInCount = finalRecipients.filter((r) => r.optedIn !== true).length;
+
+  function toggleContact(phone: string) {
+    setSelectedPhones((prev) => {
+      const next = new Set(prev);
+      if (next.has(phone)) next.delete(phone);
+      else next.add(phone);
+      return next;
+    });
+  }
+
+  function selectAllOptedIn() {
+    setSelectedPhones(new Set(contacts.filter((c) => c.optedIn).map((c) => c.phone)));
+  }
+
+  function selectAll() {
+    setSelectedPhones(new Set(contacts.map((c) => c.phone)));
+  }
+
+  function clearSelection() {
+    setSelectedPhones(new Set());
+  }
+
+  async function handleSend() {
+    setSendError(null);
+    setSendResult(null);
+
+    if (!messageTemplate.trim()) {
+      setSendError('Message is required.');
+      return;
+    }
+    if (finalRecipients.length === 0) {
+      setSendError('Select at least one recipient.');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      notOptedInCount > 0
+        ? `Send to ${finalRecipients.length} recipient(s)? ${notOptedInCount} of them have not opted in to SMS marketing.`
+        : `Send to ${finalRecipients.length} recipient(s)?`
+    );
+    if (!confirmed) return;
+
+    try {
+      setSending(true);
+      const res = await authFetch('/api/admin/sms-campaign/send-to-list', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recipients: finalRecipients.map((r) => ({ phone: r.phone, name: r.name })),
+          messageTemplate: messageTemplate.trim(),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Failed to send campaign');
+      setSendResult(data.sendResult);
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : 'Failed to send campaign');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Container maxWidth="lg" padding="xl">
+      <Stack spacing="lg">
+        <Stack spacing="sm">
+          <H1>SMS Marketing</H1>
+          <Text color="secondary">
+            Send a bulk text from the business number. Sends from the SMS/MMS messaging service configured in Twilio, with a
+            rate-limited send and an automatic opt-out notice.
+          </Text>
+        </Stack>
+
+        <Box variant="outlined" padding="md">
+          <Stack spacing="md">
+            <Stack direction="horizontal" justify="space-between" align="center">
+              <Text weight="bold">Known contacts ({contacts.length})</Text>
+              <Stack direction="horizontal" spacing="sm">
+                <Button size="sm" variant="outline" text="Select opted-in" onClick={selectAllOptedIn} />
+                <Button size="sm" variant="outline" text="Select all" onClick={selectAll} />
+                <Button size="sm" variant="outline" text="Clear" onClick={clearSelection} />
+              </Stack>
+            </Stack>
+
+            {contactsError && <Alert variant="error">{contactsError}</Alert>}
+
+            {loadingContacts ? (
+              <LoadingSpinner />
+            ) : contacts.length === 0 ? (
+              <Text color="secondary">No customer contacts found from past bookings.</Text>
+            ) : (
+              <ContactList>
+                {contacts.map((contact) => (
+                  <ContactRow key={contact.phone}>
+                    <input
+                      type="checkbox"
+                      checked={selectedPhones.has(contact.phone)}
+                      onChange={() => toggleContact(contact.phone)}
+                    />
+                    <Stack spacing="xs" style={{ flex: 1 }}>
+                      <Stack direction="horizontal" spacing="sm" align="center">
+                        <Text weight="medium">{contact.name}</Text>
+                        <Badge variant={contact.optedIn ? 'success' : 'warning'}>
+                          {contact.optedIn ? 'Opted in' : 'Not opted in'}
+                        </Badge>
+                      </Stack>
+                      <Text size="sm" color="secondary">
+                        {contact.phone}
+                        {contact.lastBookingDate ? ` • last booking ${formatDateTimeNoSeconds(contact.lastBookingDate)}` : ''}
+                      </Text>
+                    </Stack>
+                  </ContactRow>
+                ))}
+              </ContactList>
+            )}
+          </Stack>
+        </Box>
+
+        <Box variant="outlined" padding="md">
+          <Stack spacing="sm">
+            <Text weight="bold">Add numbers manually (optional)</Text>
+            <Text size="sm" color="secondary">
+              One per line. Format: <code>Name, (203) 555-1234</code> or just the phone number. These bypass the opt-in list
+              above, so use judgment on who you message.
+            </Text>
+            <Textarea
+              value={manualEntriesText}
+              onChange={(e) => setManualEntriesText(e.target.value)}
+              placeholder={'Jane Doe, (203) 555-1234\n(203) 555-9999'}
+              rows={4}
+            />
+          </Stack>
+        </Box>
+
+        <Box variant="outlined" padding="md">
+          <Stack spacing="sm">
+            <Text weight="bold">Message</Text>
+            <Text size="sm" color="secondary">
+              Use <code>{'{{name}}'}</code> to insert each recipient&apos;s first name.
+            </Text>
+            <Textarea
+              value={messageTemplate}
+              onChange={(e) => setMessageTemplate(e.target.value)}
+              placeholder="Hey {{name}}, it's Gregg from Fairfield Airport Car Service..."
+              rows={4}
+            />
+          </Stack>
+        </Box>
+
+        <Box variant="filled" padding="md">
+          <Stack spacing="sm">
+            <Text weight="bold">
+              {finalRecipients.length} recipient{finalRecipients.length === 1 ? '' : 's'} selected
+            </Text>
+            {notOptedInCount > 0 && (
+              <Alert variant="warning">
+                {notOptedInCount} of {finalRecipients.length} selected recipients have not opted in to SMS marketing.
+                Sending to them anyway is your call to make, not a technical restriction.
+              </Alert>
+            )}
+            {sendError && <Alert variant="error">{sendError}</Alert>}
+            {sendResult && (
+              <Alert variant={sendResult.failed > 0 ? 'warning' : 'success'}>
+                Sent {sendResult.successful}/{sendResult.total}
+                {sendResult.failed > 0 ? ` (${sendResult.failed} failed)` : ''}.
+              </Alert>
+            )}
+            <Button
+              variant="primary"
+              onClick={() => handleSend()}
+              disabled={sending || finalRecipients.length === 0 || !messageTemplate.trim()}
+              text={sending ? 'Sending…' : `Send to ${finalRecipients.length}`}
+            />
+          </Stack>
+        </Box>
+      </Stack>
+    </Container>
+  );
+}

--- a/src/app/(admin)/admin/marketing/sms/page.tsx
+++ b/src/app/(admin)/admin/marketing/sms/page.tsx
@@ -1,0 +1,7 @@
+export const dynamic = 'force-dynamic';
+
+import AdminSmsMarketingPageClient from './AdminSmsMarketingPageClient';
+
+export default function AdminSmsMarketingPage() {
+  return <AdminSmsMarketingPageClient />;
+}

--- a/src/app/(admin)/admin/messages/AdminMessagesPageClient.tsx
+++ b/src/app/(admin)/admin/messages/AdminMessagesPageClient.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import styled from 'styled-components';
 import { collection, limit, onSnapshot, orderBy, query } from 'firebase/firestore';
-import { Alert, Badge, Box, Button, Container, H1, LoadingSpinner, Stack, Text } from '@/design/ui';
+import { Alert, Badge, Box, Button, Container, H1, Input, LoadingSpinner, Modal, Stack, Text } from '@/design/ui';
 import { db } from '@/lib/utils/firebase';
 import { authFetch } from '@/lib/utils/auth-fetch';
 import { formatDateTimeNoSeconds } from '@/utils/formatting';
@@ -77,6 +77,11 @@ export default function AdminMessagesPageClient() {
   const [threads, setThreads] = useState<SmsThread[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [composePhone, setComposePhone] = useState('');
+  const [composeName, setComposeName] = useState('');
+  const [composeSubmitting, setComposeSubmitting] = useState(false);
+  const [composeError, setComposeError] = useState<string | null>(null);
   const [backfillState, setBackfillState] = useState<{
     loading: boolean;
     summary: string | null;
@@ -217,14 +222,56 @@ export default function AdminMessagesPageClient() {
     }
   }
 
+  function openCompose() {
+    setComposePhone('');
+    setComposeName('');
+    setComposeError(null);
+    setComposeOpen(true);
+  }
+
+  function closeCompose() {
+    if (composeSubmitting) return;
+    setComposeOpen(false);
+  }
+
+  async function handleStartConversation() {
+    if (!composePhone.trim()) {
+      setComposeError('Phone number is required.');
+      return;
+    }
+    setComposeSubmitting(true);
+    setComposeError(null);
+    try {
+      const res = await authFetch('/api/admin/messages/threads/find-or-create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phone: composePhone.trim(), name: composeName.trim() || undefined }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error || 'Could not start conversation');
+      }
+      const data = await res.json();
+      setComposeOpen(false);
+      router.push(`/admin/messages/${data.threadId}`);
+    } catch (startError) {
+      setComposeError(startError instanceof Error ? startError.message : 'Could not start conversation');
+    } finally {
+      setComposeSubmitting(false);
+    }
+  }
+
   return (
     <Container maxWidth="lg" padding="xl">
       <Stack spacing="lg">
-        <Stack spacing="sm">
-          <H1>Messages</H1>
-          <Text color="secondary">
-            Gregg&apos;s SMS inbox. Open a thread to reply through the business number.
-          </Text>
+        <Stack direction="horizontal" justify="space-between" align="flex-start">
+          <Stack spacing="sm">
+            <H1>Messages</H1>
+            <Text color="secondary">
+              Gregg&apos;s SMS inbox. Open a thread to reply through the business number.
+            </Text>
+          </Stack>
+          <Button variant="primary" size="sm" text="+ New message" onClick={openCompose} />
         </Stack>
 
         {error && <Alert variant="error">{error}</Alert>}
@@ -301,6 +348,49 @@ export default function AdminMessagesPageClient() {
           </Stack>
         </Box>
       </Stack>
+
+      <Modal
+        isOpen={composeOpen}
+        onClose={closeCompose}
+        title="New message"
+        size="sm"
+        footer={
+          <Stack direction="horizontal" spacing="sm" justify="flex-end">
+            <Button variant="secondary" onClick={closeCompose} text="Cancel" disabled={composeSubmitting} />
+            <Button
+              variant="primary"
+              onClick={() => handleStartConversation()}
+              disabled={composeSubmitting}
+              text={composeSubmitting ? 'Starting…' : 'Start conversation'}
+            />
+          </Stack>
+        }
+      >
+        <Stack spacing="md">
+          <Text color="secondary">
+            Starts (or reopens) a conversation from the business number. You&apos;ll type the first message on the thread page.
+          </Text>
+          {composeError && <Alert variant="error">{composeError}</Alert>}
+          <Stack spacing="xs">
+            <Text variant="small" weight="medium">Phone number</Text>
+            <Input
+              type="tel"
+              value={composePhone}
+              onChange={(e) => setComposePhone(e.target.value)}
+              placeholder="(203) 555-1234"
+            />
+          </Stack>
+          <Stack spacing="xs">
+            <Text variant="small" weight="medium">Name (optional)</Text>
+            <Input
+              type="text"
+              value={composeName}
+              onChange={(e) => setComposeName(e.target.value)}
+              placeholder="Customer name"
+            />
+          </Stack>
+        </Stack>
+      </Modal>
     </Container>
   );
 }

--- a/src/app/api/admin/messages/threads/find-or-create/route.ts
+++ b/src/app/api/admin/messages/threads/find-or-create/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAdmin } from '@/lib/utils/auth-server';
+import { normalizePhoneToE164 } from '@/lib/services/twilio-service';
+import { findOrCreateThread } from '@/lib/services/sms-thread-service';
+
+const schema = z.object({
+  phone: z.string().min(1),
+  name: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const authResult = await requireAdmin(request);
+  if (!authResult.ok) return authResult.response;
+
+  try {
+    const json = await request.json();
+    const parsed = schema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'phone is required' }, { status: 400 });
+    }
+
+    let normalizedPhone: string;
+    try {
+      normalizedPhone = normalizePhoneToE164(parsed.data.phone);
+    } catch {
+      return NextResponse.json({ error: 'Invalid phone number' }, { status: 400 });
+    }
+
+    const name = parsed.data.name?.trim() || null;
+    const { threadId, created } = await findOrCreateThread(normalizedPhone, name);
+
+    return NextResponse.json({ threadId, created });
+  } catch (error) {
+    console.error('Failed to find or create SMS thread:', error);
+    return NextResponse.json({ error: 'Failed to start conversation' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/sms-campaign/contacts/route.ts
+++ b/src/app/api/admin/sms-campaign/contacts/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/utils/auth-server';
+import { getContactDirectory } from '@/lib/services/sms-campaign-service';
+
+const parsePositiveInt = (value: string | null): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await requireAdmin(request);
+    if (!authResult.ok) return authResult.response;
+
+    const { searchParams } = new URL(request.url);
+    const bookingScanLimit = parsePositiveInt(searchParams.get('bookingScanLimit'));
+
+    const directory = await getContactDirectory({ bookingScanLimit });
+    return NextResponse.json(directory);
+  } catch (error) {
+    console.error('Failed to build SMS contact directory:', error);
+    return NextResponse.json({ error: 'Failed to load contacts' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/sms-campaign/send-to-list/route.ts
+++ b/src/app/api/admin/sms-campaign/send-to-list/route.ts
@@ -9,6 +9,10 @@ const schema = z.object({
       z.object({
         phone: z.string().min(1),
         name: z.string().optional().default(''),
+        // Client-reported opt-in status at send time (from the contact directory the admin
+        // reviewed) — recorded here so there's a server-side account of the decision made,
+        // since this endpoint deliberately allows sending to non-opted-in numbers.
+        optedIn: z.boolean().optional().default(false),
       })
     )
     .min(1),
@@ -29,13 +33,18 @@ export async function POST(request: NextRequest) {
 
     const { recipients, messageTemplate, dryRun } = parsed.data;
     const normalizedRecipients = recipients.map((r) => ({ phone: r.phone, name: r.name || 'there' }));
+    const optedInCount = recipients.filter((r) => r.optedIn).length;
+    const notOptedInCount = recipients.length - optedInCount;
 
     if (dryRun) {
-      return NextResponse.json({ dryRun: true, recipientCount: normalizedRecipients.length });
+      return NextResponse.json({ dryRun: true, recipientCount: normalizedRecipients.length, optedInCount, notOptedInCount });
     }
 
     const sendResult = await sendSmsToList(normalizedRecipients, messageTemplate);
-    return NextResponse.json({ success: true, sendResult });
+    console.log(
+      `[SMS Marketing] Sent to list: ${optedInCount} opted-in, ${notOptedInCount} not opted-in of ${recipients.length} total.`
+    );
+    return NextResponse.json({ success: true, sendResult, optedInCount, notOptedInCount });
   } catch (error) {
     console.error('Failed to send SMS to list:', error);
     const message = error instanceof Error ? error.message : 'Failed to send SMS campaign';

--- a/src/app/api/admin/sms-campaign/send-to-list/route.ts
+++ b/src/app/api/admin/sms-campaign/send-to-list/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAdmin } from '@/lib/utils/auth-server';
+import { sendSmsToList } from '@/lib/services/sms-campaign-service';
+
+const schema = z.object({
+  recipients: z
+    .array(
+      z.object({
+        phone: z.string().min(1),
+        name: z.string().optional().default(''),
+      })
+    )
+    .min(1),
+  messageTemplate: z.string().min(1),
+  dryRun: z.boolean().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await requireAdmin(request);
+    if (!authResult.ok) return authResult.response;
+
+    const json = await request.json().catch(() => ({}));
+    const parsed = schema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'recipients and messageTemplate are required' }, { status: 400 });
+    }
+
+    const { recipients, messageTemplate, dryRun } = parsed.data;
+    const normalizedRecipients = recipients.map((r) => ({ phone: r.phone, name: r.name || 'there' }));
+
+    if (dryRun) {
+      return NextResponse.json({ dryRun: true, recipientCount: normalizedRecipients.length });
+    }
+
+    const sendResult = await sendSmsToList(normalizedRecipients, messageTemplate);
+    return NextResponse.json({ success: true, sendResult });
+  } catch (error) {
+    console.error('Failed to send SMS to list:', error);
+    const message = error instanceof Error ? error.message : 'Failed to send SMS campaign';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/app/AdminNavigation.tsx
+++ b/src/components/app/AdminNavigation.tsx
@@ -35,6 +35,7 @@ export const AdminNavigation: React.FC = () => {
     { name: 'Bookings', href: '/admin/bookings', current: currentPath === '/admin/bookings' },
     { name: 'Payments', href: '/admin/payments', current: currentPath === '/admin/payments' },
     { name: 'Messages', href: '/admin/messages', current: currentPath.startsWith('/admin/messages') },
+    { name: 'Marketing', href: '/admin/marketing/sms', current: currentPath.startsWith('/admin/marketing') },
     { name: 'Pricing', href: '/admin/pricing', current: currentPath === '/admin/pricing' },
     { name: 'Costs', href: '/admin/costs', current: currentPath === '/admin/costs' },
     // 'Campaigns' removed: /admin/campaigns has no page (Next prefetched it -> 404).

--- a/src/lib/services/sms-campaign-service.ts
+++ b/src/lib/services/sms-campaign-service.ts
@@ -78,19 +78,12 @@ const extractBookingDate = (booking: BookingLike): Date | null => {
   );
 };
 
-export function buildSmsCampaignPreflight(
-  bookings: BookingLike[],
-  options: SmsCampaignOptions = {}
-): SmsCampaignPreflight & { internalRecipients: InternalRecipient[] } {
+function dedupeContactsByPhone(
+  bookings: BookingLike[]
+): { dedupedByPhone: Map<string, InternalRecipient & { smsOptIn: boolean }>; excludedNoPhone: number; invalidPhoneContacts: number } {
   const dedupedByPhone = new Map<string, InternalRecipient & { smsOptIn: boolean }>();
   let excludedNoPhone = 0;
-  let excludedOptedOut = 0;
   let invalidPhoneContacts = 0;
-
-  const activeCutoff =
-    typeof options.activeWithinDays === 'number' && options.activeWithinDays > 0
-      ? new Date(Date.now() - options.activeWithinDays * 24 * 60 * 60 * 1000)
-      : null;
 
   for (const booking of bookings) {
     const rawPhone = extractPhone(booking).trim();
@@ -135,6 +128,21 @@ export function buildSmsCampaignPreflight(
       existing.smsOptIn = true;
     }
   }
+
+  return { dedupedByPhone, excludedNoPhone, invalidPhoneContacts };
+}
+
+export function buildSmsCampaignPreflight(
+  bookings: BookingLike[],
+  options: SmsCampaignOptions = {}
+): SmsCampaignPreflight & { internalRecipients: InternalRecipient[] } {
+  const { dedupedByPhone, excludedNoPhone, invalidPhoneContacts } = dedupeContactsByPhone(bookings);
+  let excludedOptedOut = 0;
+
+  const activeCutoff =
+    typeof options.activeWithinDays === 'number' && options.activeWithinDays > 0
+      ? new Date(Date.now() - options.activeWithinDays * 24 * 60 * 60 * 1000)
+      : null;
 
   const recipients: InternalRecipient[] = [];
   for (const contact of dedupedByPhone.values()) {
@@ -183,6 +191,56 @@ export async function getSmsCampaignPreflight(
   const snapshot = await db.collection('bookings').orderBy('createdAt', 'desc').limit(scanLimit).get();
   const bookings = snapshot.docs.map((doc: QueryDocumentSnapshot) => doc.data() as BookingLike);
   return buildSmsCampaignPreflight(bookings, options);
+}
+
+export interface SmsContact {
+  name: string;
+  phone: string; // E.164
+  optedIn: boolean;
+  lastBookingDate: string | null;
+}
+
+// Every known contact, opted-in or not — for the mass-text picker, where Gregg chooses who
+// to message and needs to see opt-in status rather than have it silently filtered out.
+export function buildContactDirectory(
+  bookings: BookingLike[]
+): { scannedBookings: number; contacts: SmsContact[] } {
+  const { dedupedByPhone } = dedupeContactsByPhone(bookings);
+
+  const contacts: SmsContact[] = Array.from(dedupedByPhone.values()).map((contact) => ({
+    name: contact.name,
+    phone: contact.normalizedPhone,
+    optedIn: contact.smsOptIn,
+    lastBookingDate: contact.lastBookingDate?.toISOString() ?? null,
+  }));
+
+  contacts.sort((a, b) => {
+    const aTime = a.lastBookingDate ? new Date(a.lastBookingDate).getTime() : 0;
+    const bTime = b.lastBookingDate ? new Date(b.lastBookingDate).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return { scannedBookings: bookings.length, contacts };
+}
+
+export async function getContactDirectory(
+  options: Pick<SmsCampaignOptions, 'bookingScanLimit'> = {}
+): Promise<{ scannedBookings: number; contacts: SmsContact[] }> {
+  const db = getAdminDb();
+  const scanLimit = Math.min(Math.max(options.bookingScanLimit ?? DEFAULT_SCAN_LIMIT, 1), 20_000);
+  const snapshot = await db.collection('bookings').orderBy('createdAt', 'desc').limit(scanLimit).get();
+  const bookings = snapshot.docs.map((doc: QueryDocumentSnapshot) => doc.data() as BookingLike);
+  return buildContactDirectory(bookings);
+}
+
+// Sends to an explicit recipient list chosen by the admin — bypasses the opt-in filter in
+// buildSmsCampaignPreflight/sendSmsCampaign by design, since Gregg reviews opt-in status
+// himself in the picker UI and may deliberately message contacts who haven't opted in.
+export async function sendSmsToList(
+  recipients: Array<{ phone: string; name: string }>,
+  messageTemplate: string
+) {
+  return sendBulkSms(recipients, messageTemplate, { includeOptOutNotice: true });
 }
 
 export async function sendSmsCampaign(

--- a/tests/unit/admin-messaging-compose.route.test.ts
+++ b/tests/unit/admin-messaging-compose.route.test.ts
@@ -1,0 +1,139 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextResponse } from 'next/server';
+
+vi.mock('@/lib/utils/auth-server', () => ({
+  requireAdmin: vi.fn().mockResolvedValue({ ok: true, auth: { uid: 'admin-1', role: 'admin' } }),
+}));
+
+vi.mock('@/lib/services/sms-thread-service', () => ({
+  findOrCreateThread: vi.fn().mockResolvedValue({ threadId: 'thread_1', created: true }),
+}));
+
+vi.mock('@/lib/services/sms-campaign-service', () => ({
+  getContactDirectory: vi.fn().mockResolvedValue({
+    scannedBookings: 2,
+    contacts: [
+      { name: 'Opted In', phone: '+12035551234', optedIn: true, lastBookingDate: '2026-03-03T12:00:00.000Z' },
+      { name: 'Not Opted In', phone: '+12035550000', optedIn: false, lastBookingDate: null },
+    ],
+  }),
+  sendSmsToList: vi.fn().mockResolvedValue({ total: 2, successful: 2, failed: 0, results: [] }),
+}));
+
+import { findOrCreateThread } from '@/lib/services/sms-thread-service';
+import { getContactDirectory, sendSmsToList } from '@/lib/services/sms-campaign-service';
+
+const mockFindOrCreateThread = findOrCreateThread as unknown as ReturnType<typeof vi.fn>;
+const mockGetContactDirectory = getContactDirectory as unknown as ReturnType<typeof vi.fn>;
+const mockSendSmsToList = sendSmsToList as unknown as ReturnType<typeof vi.fn>;
+
+let findOrCreateRoute: typeof import('@/app/api/admin/messages/threads/find-or-create/route').POST;
+let contactsRoute: typeof import('@/app/api/admin/sms-campaign/contacts/route').GET;
+let sendToListRoute: typeof import('@/app/api/admin/sms-campaign/send-to-list/route').POST;
+
+beforeAll(async () => {
+  ({ POST: findOrCreateRoute } = await import('@/app/api/admin/messages/threads/find-or-create/route'));
+  ({ GET: contactsRoute } = await import('@/app/api/admin/sms-campaign/contacts/route'));
+  ({ POST: sendToListRoute } = await import('@/app/api/admin/sms-campaign/send-to-list/route'));
+});
+
+// Route handlers always return a NextResponse at runtime; the dynamic import type is loose.
+const asResponse = (value: NextResponse | undefined): NextResponse => value as NextResponse;
+
+describe('admin messaging compose routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes the phone number and finds or creates a thread', async () => {
+    const response = asResponse(
+      await findOrCreateRoute(
+        new Request('http://localhost/api/admin/messages/threads/find-or-create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phone: '(203) 555-1234', name: 'Jane Doe' }),
+        }) as any
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockFindOrCreateThread).toHaveBeenCalledWith('+12035551234', 'Jane Doe');
+    const payload = await response.json();
+    expect(payload).toEqual({ threadId: 'thread_1', created: true });
+  });
+
+  it('rejects an invalid phone number on find-or-create', async () => {
+    const response = asResponse(
+      await findOrCreateRoute(
+        new Request('http://localhost/api/admin/messages/threads/find-or-create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phone: 'not-a-phone' }),
+        }) as any
+      )
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockFindOrCreateThread).not.toHaveBeenCalled();
+  });
+
+  it('returns the full contact directory including non-opted-in contacts', async () => {
+    const response = asResponse(
+      await contactsRoute(new Request('http://localhost/api/admin/sms-campaign/contacts') as any)
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.contacts).toHaveLength(2);
+    expect(payload.contacts.some((c: { optedIn: boolean }) => c.optedIn === false)).toBe(true);
+    expect(mockGetContactDirectory).toHaveBeenCalled();
+  });
+
+  it('sends to an explicit recipient list regardless of opt-in status', async () => {
+    const response = asResponse(
+      await sendToListRoute(
+        new Request('http://localhost/api/admin/sms-campaign/send-to-list', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            recipients: [
+              { phone: '+12035551234', name: 'Opted In' },
+              { phone: '+12035550000', name: 'Not Opted In' },
+            ],
+            messageTemplate: 'Hey {{name}}, quick update from Fairfield Airport Cars.',
+          }),
+        }) as any
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSendSmsToList).toHaveBeenCalledWith(
+      [
+        { phone: '+12035551234', name: 'Opted In' },
+        { phone: '+12035550000', name: 'Not Opted In' },
+      ],
+      'Hey {{name}}, quick update from Fairfield Airport Cars.'
+    );
+  });
+
+  it('does not send when dryRun is true', async () => {
+    const response = asResponse(
+      await sendToListRoute(
+        new Request('http://localhost/api/admin/sms-campaign/send-to-list', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            recipients: [{ phone: '+12035551234', name: 'Opted In' }],
+            messageTemplate: 'Test',
+            dryRun: true,
+          }),
+        }) as any
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual({ dryRun: true, recipientCount: 1 });
+    expect(mockSendSmsToList).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/admin-messaging-compose.route.test.ts
+++ b/tests/unit/admin-messaging-compose.route.test.ts
@@ -97,8 +97,8 @@ describe('admin messaging compose routes', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             recipients: [
-              { phone: '+12035551234', name: 'Opted In' },
-              { phone: '+12035550000', name: 'Not Opted In' },
+              { phone: '+12035551234', name: 'Opted In', optedIn: true },
+              { phone: '+12035550000', name: 'Not Opted In', optedIn: false },
             ],
             messageTemplate: 'Hey {{name}}, quick update from Fairfield Airport Cars.',
           }),
@@ -114,16 +114,19 @@ describe('admin messaging compose routes', () => {
       ],
       'Hey {{name}}, quick update from Fairfield Airport Cars.'
     );
+    const payload = await response.json();
+    expect(payload.optedInCount).toBe(1);
+    expect(payload.notOptedInCount).toBe(1);
   });
 
-  it('does not send when dryRun is true', async () => {
+  it('records opt-in counts on a dry run without sending', async () => {
     const response = asResponse(
       await sendToListRoute(
         new Request('http://localhost/api/admin/sms-campaign/send-to-list', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            recipients: [{ phone: '+12035551234', name: 'Opted In' }],
+            recipients: [{ phone: '+12035551234', name: 'Opted In', optedIn: true }],
             messageTemplate: 'Test',
             dryRun: true,
           }),
@@ -133,7 +136,7 @@ describe('admin messaging compose routes', () => {
 
     expect(response.status).toBe(200);
     const payload = await response.json();
-    expect(payload).toEqual({ dryRun: true, recipientCount: 1 });
+    expect(payload).toEqual({ dryRun: true, recipientCount: 1, optedInCount: 1, notOptedInCount: 0 });
     expect(mockSendSmsToList).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/sms-campaign-service.test.ts
+++ b/tests/unit/sms-campaign-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSmsCampaignPreflight } from '@/lib/services/sms-campaign-service';
+import { buildContactDirectory, buildSmsCampaignPreflight } from '@/lib/services/sms-campaign-service';
 
 describe('sms-campaign-service', () => {
   it('includes only smsOptIn recipients and deduplicates by phone', () => {
@@ -55,5 +55,36 @@ describe('sms-campaign-service', () => {
     const result = buildSmsCampaignPreflight(bookings, { activeWithinDays: 30 });
     expect(result.optedInContacts).toBe(1);
     expect(result.recipients[0]?.name).toBe('Recent');
+  });
+});
+
+describe('buildContactDirectory', () => {
+  it('includes every deduplicated contact regardless of opt-in status', () => {
+    const bookings = [
+      { customer: { name: 'Opted In', phone: '(203) 555-1234', smsOptIn: true }, createdAt: '2026-03-03T12:00:00.000Z' },
+      { customer: { name: 'Not Opted In', phone: '+12035550000', smsOptIn: false }, createdAt: '2026-03-02T12:00:00.000Z' },
+    ];
+
+    const { contacts, scannedBookings } = buildContactDirectory(bookings);
+
+    expect(scannedBookings).toBe(2);
+    expect(contacts).toHaveLength(2);
+    expect(contacts.find((c) => c.phone === '+12035551234')).toMatchObject({ name: 'Opted In', optedIn: true });
+    expect(contacts.find((c) => c.phone === '+12035550000')).toMatchObject({ name: 'Not Opted In', optedIn: false });
+  });
+
+  it('excludes contacts with missing or invalid phone numbers, and sorts by most recent booking', () => {
+    const bookings = [
+      { customer: { name: 'No Phone', phone: '', smsOptIn: true }, createdAt: '2026-03-03T12:00:00.000Z' },
+      { customer: { name: 'Bad Phone', phone: 'abc', smsOptIn: true }, createdAt: '2026-03-03T12:00:00.000Z' },
+      { customer: { name: 'Older', phone: '+12035551111', smsOptIn: false }, createdAt: '2026-01-01T12:00:00.000Z' },
+      { customer: { name: 'Newer', phone: '+12035552222', smsOptIn: false }, createdAt: '2026-03-03T12:00:00.000Z' },
+    ];
+
+    const { contacts } = buildContactDirectory(bookings);
+
+    expect(contacts).toHaveLength(2);
+    expect(contacts[0].name).toBe('Newer');
+    expect(contacts[1].name).toBe('Older');
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #53. Gregg could only reply to threads customers started — no way to message someone first (booking reminders, ETA updates), and no UI for bulk/marketing sends despite the backend already supporting it.

- "Text customer" button on each booking row — finds-or-creates a thread and opens the composer, sending from the business number.
- "New message" compose modal on the SMS inbox for numbers with no existing thread.
- Revived `/admin/marketing/sms` (added back to nav as "Marketing") with a contact directory showing every past customer and their opt-in status, manual number entry, and a send flow that lets Gregg knowingly message non-opted-in contacts rather than silently blocking them — server now also records opt-in counts at send time as a minimal audit trail.

New: `POST /api/admin/messages/threads/find-or-create`, `GET /api/admin/sms-campaign/contacts`, `POST /api/admin/sms-campaign/send-to-list`. `sms-campaign-service` gets an unfiltered `buildContactDirectory`/`getContactDirectory` alongside the existing opt-in-only campaign path, which is unchanged.

## Test plan
- [x] Full unit suite: 333/333 passing
- [x] Full integration suite: 130/130 passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (0 errors)
- [x] Production build succeeds, all new routes present in route manifest
- [x] Passed 2 rounds of yp-staff-review (type safety, API contract, backward compat, security) — one real finding (opt-in status not recorded server-side) fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)