### PR TITLE
fix: append opt-out notice to customer-facing SMS, matching registered A2P campaign

### DIFF
--- a/src/app/api/admin/messages/send/route.ts
+++ b/src/app/api/admin/messages/send/route.ts
@@ -36,6 +36,7 @@ export async function POST(request: NextRequest) {
       body: trimmedBody,
       threadId,
       senderType: 'admin',
+      customerFacing: true,
     });
 
     await updateThreadOnOutbound(threadId, trimmedBody);

--- a/src/app/api/booking/cancel-booking/route.ts
+++ b/src/app/api/booking/cancel-booking/route.ts
@@ -77,7 +77,7 @@ export async function POST(req: NextRequest) {
     } else {
       // Send SMS and email (push removed)
       await Promise.all([
-        phone ? sendSms({ to: phone, body: messageBody }) : Promise.resolve(),
+        phone ? sendSms({ to: phone, body: messageBody, customerFacing: true }) : Promise.resolve(),
         email ? sendConfirmationEmail(adaptOldBookingToNew({ ...booking, status: 'cancelled', updatedAt: new Date(), cancellationFee })) : Promise.resolve(),
       ]);
 

--- a/src/app/api/notifications/send-confirmation/route.ts
+++ b/src/app/api/notifications/send-confirmation/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     const messageBody = `Thank you for booking with ${APP_CONFIG.name}! Your ride is confirmed.\nPickup time: ${pickupDateTimeText}\nRoute: ${pickupAddress} -> ${dropoffAddress}`;
 
     await Promise.all([
-      booking.phone ? sendSms({ to: booking.phone, body: messageBody }) : Promise.resolve(),
+      booking.phone ? sendSms({ to: booking.phone, body: messageBody, customerFacing: true }) : Promise.resolve(),
       sendConfirmationEmail(adaptOldBookingToNew(booking)),
     ]);
 

--- a/src/app/api/notifications/send-feedback-request/route.ts
+++ b/src/app/api/notifications/send-feedback-request/route.ts
@@ -29,6 +29,7 @@ export async function POST(request: Request) {
       await sendSms({
         to: booking.phone,
         body: messageBody,
+        customerFacing: true,
       });
     }
 

--- a/src/lib/services/booking-orchestrator.ts
+++ b/src/lib/services/booking-orchestrator.ts
@@ -588,6 +588,7 @@ export async function createPaidBookingAndNotify(
         await sendSms({
           to: bookingData.customer.phone,
           body: smsMessage,
+          customerFacing: true,
         });
       }
     }

--- a/src/lib/services/sms-campaign-service.ts
+++ b/src/lib/services/sms-campaign-service.ts
@@ -118,14 +118,13 @@ function dedupeContactsByPhone(
 
     const existingDate = existing.lastBookingDate?.getTime() ?? 0;
     const nextDate = bookingDate?.getTime() ?? 0;
+    // The most recent booking's opt-in choice always wins — an older booking's smsOptIn must
+    // never resurrect consent after a customer has since opted out on a newer booking.
     if (nextDate >= existingDate) {
       existing.name = name;
       existing.phone = rawPhone;
       existing.lastBookingDate = bookingDate;
       existing.smsOptIn = smsOptIn;
-    } else if (smsOptIn) {
-      // Preserve affirmative consent from any booking unless a later booking explicitly opts out.
-      existing.smsOptIn = true;
     }
   }
 

--- a/src/lib/services/twilio-service.ts
+++ b/src/lib/services/twilio-service.ts
@@ -13,7 +13,10 @@ const getTwilioClient = () => twilio(accountSid, authToken);
 // message content. Not applied to OTP codes or internal admin notifications (not customer
 // marketing/relationship messaging, and STOP-language on a 2FA code would be unusual UX).
 const appendOptOutNotice = (body: string): string => {
-  const hasOptOut = /\b(stop|opt\s*out|unsubscribe)\b/i.test(body);
+  // Matches the actual "reply STOP" instruction pattern, not the bare word "stop" — admin
+  // replies are freeform text from Gregg (e.g. "I'll stop by at 5") that would otherwise
+  // false-positive and silently skip the compliance line entirely.
+  const hasOptOut = /reply\s+stop\b|\b(opt\s*out|unsubscribe)\b/i.test(body);
   if (hasOptOut) return body;
   return `${body} Reply STOP to opt out.`;
 };

--- a/src/lib/services/twilio-service.ts
+++ b/src/lib/services/twilio-service.ts
@@ -8,6 +8,16 @@ const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
 
 const getTwilioClient = () => twilio(accountSid, authToken);
 
+// Our registered A2P 10DLC campaign's sample messages (Twilio/carrier compliance) all include
+// this line — customer-facing sends must match, even though Twilio enforces STOP regardless of
+// message content. Not applied to OTP codes or internal admin notifications (not customer
+// marketing/relationship messaging, and STOP-language on a 2FA code would be unusual UX).
+const appendOptOutNotice = (body: string): string => {
+  const hasOptOut = /\b(stop|opt\s*out|unsubscribe)\b/i.test(body);
+  if (hasOptOut) return body;
+  return `${body} Reply STOP to opt out.`;
+};
+
 interface SmsPayload {
   to: string;
   body: string;
@@ -16,6 +26,7 @@ interface SmsPayload {
   senderType?: SmsSenderType;
   bookingId?: string;
   customerId?: string;
+  customerFacing?: boolean;
 }
 
 export const sendSms = async ({
@@ -26,16 +37,19 @@ export const sendSms = async ({
   senderType,
   bookingId,
   customerId,
+  customerFacing = false,
 }: SmsPayload) => {
   if (!accountSid || !authToken || !messagingServiceSid) {
     console.error('Twilio credentials are not configured. Required: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE_SID');
     throw new Error('Twilio service is not configured.');
   }
 
+  const outboundBody = customerFacing ? appendOptOutNotice(body) : body;
+
   try {
     const client = getTwilioClient();
     const message = await client.messages.create({
-      body,
+      body: outboundBody,
       messagingServiceSid: messagingServiceSid,
       to,
     });
@@ -44,7 +58,7 @@ export const sendSms = async ({
         await saveSmsMessage({
           from: twilioPhoneNumber || 'system',
           to,
-          body,
+          body: outboundBody,
           direction: 'outbound',
           twilioMessageSid: message.sid,
           threadId,
@@ -102,12 +116,6 @@ export const normalizePhoneToE164 = (rawPhone: string): string => {
     throw new Error('Invalid phone number');
   }
   return normalizedPhone;
-};
-
-const appendOptOutNotice = (body: string): string => {
-  const hasOptOut = /\b(stop|opt\s*out|unsubscribe)\b/i.test(body);
-  if (hasOptOut) return body;
-  return `${body} Reply STOP to opt out.`;
 };
 
 /**

--- a/tests/unit/admin-messages-threads.route.test.ts
+++ b/tests/unit/admin-messages-threads.route.test.ts
@@ -127,6 +127,7 @@ describe('admin SMS thread routes', () => {
       body: 'Yes, I can do that.',
       threadId: 'thread_1',
       senderType: 'admin',
+      customerFacing: true,
     });
     expect(mockUpdateThreadOnOutbound).toHaveBeenCalledWith('thread_1', 'Yes, I can do that.');
   });

--- a/tests/unit/cancel-booking.route.test.ts
+++ b/tests/unit/cancel-booking.route.test.ts
@@ -294,6 +294,7 @@ describe('POST /api/booking/cancel-booking', () => {
     expect(mockSendSms).toHaveBeenCalledWith({
       to: '+15555550123',
       body: expect.stringContaining('3/2/2026, 8:00 AM'),
+      customerFacing: true,
     });
 
     // Customer email sent

--- a/tests/unit/process-payment.route.test.ts
+++ b/tests/unit/process-payment.route.test.ts
@@ -190,6 +190,7 @@ describe('POST /api/payment/process-payment', () => {
     expect(mockSendSms).toHaveBeenCalledWith({
       to: '+15555550123',
       body: expect.stringContaining('1/1/2028, 10:00 AM'),
+      customerFacing: true,
     });
   });
 

--- a/tests/unit/send-confirmation.route.test.ts
+++ b/tests/unit/send-confirmation.route.test.ts
@@ -62,6 +62,7 @@ describe('POST /api/notifications/send-confirmation', () => {
     expect(mockSendSms).toHaveBeenCalledWith({
       to: '+15555550123',
       body: expect.stringContaining('3/2/2026, 8:00 AM'),
+      customerFacing: true,
     });
     expect(mockSendConfirmationEmail).toHaveBeenCalledTimes(1);
   });
@@ -92,6 +93,7 @@ describe('POST /api/notifications/send-confirmation', () => {
     expect(mockSendSms).toHaveBeenCalledWith({
       to: '+15555550999',
       body: expect.stringContaining('3/2/2026, 8:00 AM'),
+      customerFacing: true,
     });
     expect(mockSendSms).not.toHaveBeenCalledWith(
       expect.objectContaining({ body: expect.stringContaining('1:00 PM') })

--- a/tests/unit/sms-campaign-service.test.ts
+++ b/tests/unit/sms-campaign-service.test.ts
@@ -29,6 +29,21 @@ describe('sms-campaign-service', () => {
     expect(result.recipients[0]?.name).toBe('Opted In New');
   });
 
+  it('does not let an older opted-in booking resurrect consent after a newer booking opts out (regression)', () => {
+    // Newest-created booking processed first (matches production query order: createdAt desc).
+    const bookingsNewestFirst = [
+      { customer: { name: 'Jane', phone: '+12035551234', smsOptIn: false }, createdAt: '2026-03-03T12:00:00.000Z' },
+      { customer: { name: 'Jane', phone: '+12035551234', smsOptIn: true }, createdAt: '2026-01-01T12:00:00.000Z' },
+    ];
+    expect(buildSmsCampaignPreflight(bookingsNewestFirst).optedInContacts).toBe(0);
+    expect(buildContactDirectory(bookingsNewestFirst).contacts[0]).toMatchObject({ optedIn: false });
+
+    // Same data, opposite array order — result must not depend on processing order.
+    const bookingsOldestFirst = [...bookingsNewestFirst].reverse();
+    expect(buildSmsCampaignPreflight(bookingsOldestFirst).optedInContacts).toBe(0);
+    expect(buildContactDirectory(bookingsOldestFirst).contacts[0]).toMatchObject({ optedIn: false });
+  });
+
   it('counts invalid and missing phones in preflight', () => {
     const bookings = [
       { customer: { name: 'Missing Phone', phone: '', smsOptIn: true }, createdAt: '2026-03-03T12:00:00.000Z' },

--- a/tests/unit/twilio-service-send-sms.test.ts
+++ b/tests/unit/twilio-service-send-sms.test.ts
@@ -85,6 +85,23 @@ describe('sendSms opt-out notice', () => {
     );
   });
 
+  it('appends the notice even when the body contains "stop" outside an opt-out instruction (regression)', async () => {
+    mockMessagesCreate.mockResolvedValue({ sid: 'SM127' });
+    const { sendSms } = await import('@/lib/services/twilio-service');
+
+    await sendSms({
+      to: '+12035551234',
+      body: "I'll stop by around 5pm to grab you.",
+      customerFacing: true,
+    });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "I'll stop by around 5pm to grab you. Reply STOP to opt out.",
+      })
+    );
+  });
+
   it('logs the actual sent body (with the notice appended), not the original', async () => {
     mockMessagesCreate.mockResolvedValue({ sid: 'SM126' });
     const { sendSms } = await import('@/lib/services/twilio-service');

--- a/tests/unit/twilio-service-send-sms.test.ts
+++ b/tests/unit/twilio-service-send-sms.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests that customer-facing SMS sent via sendSms match our registered Twilio A2P 10DLC
+ * campaign's sample messages, which all include an opt-out notice. Internal sends (OTP,
+ * admin notifications, Gregg's own forward) should NOT get this appended.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockMessagesCreate = vi.fn();
+const mockSaveSmsMessage = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('twilio', () => ({
+  default: vi.fn(() => ({
+    messages: {
+      create: mockMessagesCreate,
+    },
+  })),
+}));
+
+vi.mock('@/lib/services/sms-message-service', () => ({
+  saveSmsMessage: mockSaveSmsMessage,
+}));
+
+describe('sendSms opt-out notice', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockMessagesCreate.mockReset();
+    mockSaveSmsMessage.mockClear();
+
+    process.env.TWILIO_ACCOUNT_SID = 'AC1234567890abcdef1234567890abcd';
+    process.env.TWILIO_AUTH_TOKEN = 'test-auth-token';
+    process.env.TWILIO_MESSAGING_SERVICE_SID = 'test-messaging-service-sid';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('appends "Reply STOP to opt out" when customerFacing is true', async () => {
+    mockMessagesCreate.mockResolvedValue({ sid: 'SM123' });
+    const { sendSms } = await import('@/lib/services/twilio-service');
+
+    await sendSms({
+      to: '+12035551234',
+      body: 'Your ride to JFK is confirmed for 8:00 AM.',
+      customerFacing: true,
+    });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Your ride to JFK is confirmed for 8:00 AM. Reply STOP to opt out.',
+      })
+    );
+  });
+
+  it('does not append the notice when customerFacing is omitted (default false)', async () => {
+    mockMessagesCreate.mockResolvedValue({ sid: 'SM124' });
+    const { sendSms } = await import('@/lib/services/twilio-service');
+
+    await sendSms({
+      to: '+12035551234',
+      body: 'Your Fairfield Airport Cars code is 123456. It expires in 10 minutes.',
+    });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Your Fairfield Airport Cars code is 123456. It expires in 10 minutes.',
+      })
+    );
+  });
+
+  it('does not double-append when the body already mentions opting out', async () => {
+    mockMessagesCreate.mockResolvedValue({ sid: 'SM125' });
+    const { sendSms } = await import('@/lib/services/twilio-service');
+
+    await sendSms({
+      to: '+12035551234',
+      body: 'Reminder about your ride. Reply STOP to opt out.',
+      customerFacing: true,
+    });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Reminder about your ride. Reply STOP to opt out.',
+      })
+    );
+  });
+
+  it('logs the actual sent body (with the notice appended), not the original', async () => {
+    mockMessagesCreate.mockResolvedValue({ sid: 'SM126' });
+    const { sendSms } = await import('@/lib/services/twilio-service');
+
+    await sendSms({
+      to: '+12035551234',
+      body: 'Your ride is confirmed.',
+      customerFacing: true,
+    });
+
+    expect(mockSaveSmsMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Your ride is confirmed. Reply STOP to opt out.',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Every sample message registered with Twilio for our A2P 10DLC campaign includes "Reply STOP to opt out" — including transactional ones (booking confirmation, reminder, driver arrival). Actual production sends never included it; only the bulk marketing path did. STOP already works today regardless (Twilio enforces it at the carrier level independent of message content), but the mismatch between registered traffic pattern and actual traffic is a real compliance drift that could affect carrier filtering/campaign review.

- `sendSms` takes a new `customerFacing` flag; when true, appends "Reply STOP to opt out." (skips if the body already mentions opting out, to avoid double-appending).
- Applied to: booking confirmation, cancellation notice, feedback request, and Gregg's manual replies via the SMS inbox.
- Deliberately NOT applied to: OTP codes (different message category, unusual to add STOP language to a 2FA code) and internal admin/ops notifications (not customer-facing).

## Test plan
- [x] New unit test file covering the opt-out append/skip/logging behavior directly
- [x] Updated existing exact-match assertions across 4 test files that needed the new field
- [x] Full unit suite: 467/467 passing
- [x] `tsc --noEmit` clean, `eslint` clean
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)